### PR TITLE
Separate add_node

### DIFF
--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -18,6 +18,7 @@ use rayon::prelude::*;
 
 use crate::ciphersuite::{signable::*, *};
 use crate::codec::*;
+use crate::creds::*;
 use crate::extensions::*;
 use crate::key_packages::*;
 use crate::messages::{proposals::*, *};
@@ -472,6 +473,54 @@ impl RatchetTree {
             self.nodes[path[i].as_usize()].node = Some(node);
         }
     }
+
+    /// Add nodes for the provided key packages.
+    pub(crate) fn add_nodes(
+        &mut self,
+        new_kp_in_place: &[KeyPackage],
+        new_kp_append: &[KeyPackage],
+    ) -> Vec<(NodeIndex, Credential)> {
+        let num_new_kp = new_kp_in_place.len() + new_kp_append.len();
+        let mut added_members = Vec::with_capacity(num_new_kp);
+
+        if num_new_kp > (2 * self.leaf_count().as_usize()) {
+            self.nodes
+                .reserve_exact((2 * num_new_kp) - (2 * self.leaf_count().as_usize()));
+        }
+
+        for (new_kp, leaf_index) in new_kp_in_place.iter().zip(self.free_leaves()) {
+            self.nodes[leaf_index.as_usize()] = Node::new_leaf(Some(new_kp.clone()));
+            let dirpath = treemath::dirpath_root(leaf_index, self.leaf_count());
+            for d in dirpath.iter() {
+                if !self.nodes[d.as_usize()].is_blank() {
+                    let node = &self.nodes[d.as_usize()];
+                    let index = d.as_u32();
+                    // TODO handle error
+                    let mut parent_node = node.node.clone().unwrap();
+                    if !parent_node.get_unmerged_leaves().contains(&index) {
+                        parent_node.get_unmerged_leaves_mut().push(index);
+                    }
+                    self.nodes[d.as_usize()].node = Some(parent_node);
+                }
+            }
+            added_members.push((leaf_index, new_kp.get_credential().clone()));
+        }
+        let mut new_nodes = Vec::with_capacity(num_new_kp * 2);
+        let mut leaf_index = self.nodes.len() + 1;
+        for add_proposal in new_kp_append.iter() {
+            new_nodes.extend(vec![
+                Node::new_blank_parent_node(),
+                Node::new_leaf(Some(add_proposal.clone())),
+            ]);
+            let node_index = NodeIndex::from(leaf_index);
+            added_members.push((node_index, add_proposal.get_credential().clone()));
+            leaf_index += 2;
+        }
+        self.nodes.extend(new_nodes);
+        self.trim_tree();
+        added_members
+    }
+
     pub fn apply_proposals(
         &mut self,
         proposal_id_list: &ProposalIDList,
@@ -480,7 +529,6 @@ impl RatchetTree {
     ) -> (MembershipChanges, Vec<(NodeIndex, AddProposal)>, bool) {
         let mut updated_members = vec![];
         let mut removed_members = vec![];
-        let mut added_members = Vec::with_capacity(proposal_id_list.adds.len());
         let mut invited_members = Vec::with_capacity(proposal_id_list.adds.len());
 
         let mut self_removed = false;
@@ -522,12 +570,8 @@ impl RatchetTree {
             self.blank_member(removed);
         }
 
-        if !proposal_id_list.adds.is_empty() {
-            if proposal_id_list.adds.len() > (2 * self.leaf_count().as_usize()) {
-                self.nodes.reserve_exact(
-                    (2 * proposal_id_list.adds.len()) - (2 * self.leaf_count().as_usize()),
-                );
-            }
+        // Process adds
+        let added_members = if !proposal_id_list.adds.is_empty() {
             let add_proposals: Vec<AddProposal> = proposal_id_list
                 .adds
                 .par_iter()
@@ -537,48 +581,27 @@ impl RatchetTree {
                     proposal.as_add().unwrap()
                 })
                 .collect();
-
-            let free_leaves = self.free_leaves();
             // TODO make sure intermediary nodes are updated with unmerged_leaves
-            let (add_in_place, add_append) = add_proposals.split_at(free_leaves.len());
-            for (add_proposal, leaf_index) in add_in_place.iter().zip(free_leaves) {
-                self.nodes[leaf_index.as_usize()] =
-                    Node::new_leaf(Some(add_proposal.key_package.clone()));
-                let dirpath = treemath::dirpath_root(leaf_index, self.leaf_count());
-                for d in dirpath.iter() {
-                    if !self.nodes[d.as_usize()].is_blank() {
-                        let node = &self.nodes[d.as_usize()];
-                        let index = d.as_u32();
-                        // TODO handle error
-                        let mut parent_node = node.node.clone().unwrap();
-                        if !parent_node.get_unmerged_leaves().contains(&index) {
-                            parent_node.get_unmerged_leaves_mut().push(index);
-                        }
-                        self.nodes[d.as_usize()].node = Some(parent_node);
-                    }
-                }
-                added_members.push(add_proposal.key_package.get_credential().clone());
-                invited_members.push((leaf_index, add_proposal.clone()));
+            let (add_in_place, add_append) = add_proposals.split_at(self.free_leaves().len());
+
+            let add_in_place: Vec<KeyPackage> =
+                add_in_place.iter().map(|a| a.key_package.clone()).collect();
+            let add_append: Vec<KeyPackage> =
+                add_append.iter().map(|a| a.key_package.clone()).collect();
+            let added = self.add_nodes(&add_in_place, &add_append);
+
+            for (i, added) in added.iter().enumerate() {
+                invited_members.push((added.0, add_proposals.get(i).unwrap().clone()));
             }
-            let mut new_nodes = Vec::with_capacity(proposal_id_list.adds.len() * 2);
-            let mut leaf_index = self.nodes.len() + 1;
-            for add_proposal in add_append.iter() {
-                new_nodes.extend(vec![
-                    Node::new_blank_parent_node(),
-                    Node::new_leaf(Some(add_proposal.key_package.clone())),
-                ]);
-                added_members.push(add_proposal.key_package.get_credential().clone());
-                invited_members.push((NodeIndex::from(leaf_index), add_proposal.clone()));
-                leaf_index += 2;
-            }
-            self.nodes.extend(new_nodes);
-            self.trim_tree();
-        }
+            added
+        } else {
+            Vec::new()
+        };
         (
             MembershipChanges {
                 updates: updated_members,
                 removes: removed_members,
-                adds: added_members,
+                adds: added_members.iter().map(|(_, n)| n.clone()).collect(),
             },
             invited_members,
             self_removed,

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -52,54 +52,35 @@ fn test_tree_hash() {
     use crate::creds::*;
     use crate::tree::*;
 
+    fn create_identity(id: &[u8], ciphersuite: &Ciphersuite) -> KeyPackageBundle {
+        let signature_keypair = ciphersuite.new_signature_keypair();
+        let identity = Identity::new(ciphersuite.clone(), id.to_vec());
+        let credential = Credential::Basic(BasicCredential::from(&identity));
+        let kbp = KeyPackageBundle::new(
+            &ciphersuite,
+            signature_keypair.get_private_key(),
+            credential,
+            None,
+        );
+        kbp
+    }
+
     let csuite = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let ciphersuite = Ciphersuite::new(csuite);
-    let signature_keypair = ciphersuite.new_signature_keypair();
-    let identity = Identity::new(ciphersuite.clone(), b"Tree creator".to_vec());
-    let credential = Credential::Basic(BasicCredential::from(&identity));
+    let kbp = create_identity(b"Tree creator", &ciphersuite);
 
-    let kbp = KeyPackageBundle::new(
-        &ciphersuite,
-        signature_keypair.get_private_key(),
-        credential,
-        None,
-    );
-
+    // Initialise tree
     let mut tree = RatchetTree::new(ciphersuite, kbp);
-    println!("Tree: {:?}", tree);
     let tree_hash = tree.compute_tree_hash();
     println!("Tree hash: {:?}", tree_hash);
 
-    // // Add 5 leaves to the tree.
-    // for _ in 0..5 {
-    //     tree.add_leaf();
-    // }
-    // println!("Tree:\n{}", tree);
-
-    // // Check some tree properties.
-    // assert_eq!(tree.get_height(), 3);
-    // assert_eq!(tree.num_nodes(), 9);
-
-    // // Compute hash for all leaves first
-    // for i in 0..5 {
-    //     let leaf_i = tree.get_leaf_node(i).unwrap();
-    //     let hash = tree.hash_node(leaf_i).unwrap();
-    //     println!("Hash of {}: {:?}", leaf_i, hash);
-    //     println!("Leaf {}: {:?}", i, leaf_i);
-    // }
-
-    // // Compute hash for nodes on level > 0 that's not root.
-    // for level in 1..tree.get_height() {
-    //     let level = tree.get_level(level);
-    //     for node in level.iter() {
-    //         let hash = tree.hash_node(node).unwrap();
-    //         println!("Hash of {}: {:?}", node, hash);
-    //         println!("Node {}: {:?}", node, node);
-    //     }
-    // }
-
-    // // Compute tree hash (hash of root node)
-    // let root = tree.get_root();
-    // let tree_hash = tree.hash_node(root);
-    // println!("Tree hash: {:?}", tree_hash);
+    // Add 5 nodes to the tree.
+    let mut nodes = Vec::new();
+    for _ in 0..5 {
+        nodes.push(create_identity(b"Tree creator", &ciphersuite));
+    }
+    let key_packages: Vec<KeyPackage> = nodes.iter().map(|kbp| kbp.key_package.clone()).collect();
+    let _ = tree.add_nodes(&key_packages);
+    let tree_hash = tree.compute_tree_hash();
+    println!("Tree hash: {:?}", tree_hash);
 }

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -1,8 +1,7 @@
-
 #[test]
 fn verify_binary_test_vector_treemath() {
-    use crate::tree::*;
     use crate::tree::treemath;
+    use crate::tree::*;
     use std::fs::File;
     use std::io::Read;
 
@@ -45,4 +44,62 @@ fn verify_binary_test_vector_treemath() {
         );
     }
     assert_eq!(cursor.has_more(), false);
+}
+
+#[test]
+fn test_tree_hash() {
+    use crate::ciphersuite::*;
+    use crate::creds::*;
+    use crate::tree::*;
+
+    let csuite = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let ciphersuite = Ciphersuite::new(csuite);
+    let signature_keypair = ciphersuite.new_signature_keypair();
+    let identity = Identity::new(ciphersuite.clone(), b"Tree creator".to_vec());
+    let credential = Credential::Basic(BasicCredential::from(&identity));
+
+    let kbp = KeyPackageBundle::new(
+        &ciphersuite,
+        signature_keypair.get_private_key(),
+        credential,
+        None,
+    );
+
+    let mut tree = RatchetTree::new(ciphersuite, kbp);
+    println!("Tree: {:?}", tree);
+    let tree_hash = tree.compute_tree_hash();
+    println!("Tree hash: {:?}", tree_hash);
+
+    // // Add 5 leaves to the tree.
+    // for _ in 0..5 {
+    //     tree.add_leaf();
+    // }
+    // println!("Tree:\n{}", tree);
+
+    // // Check some tree properties.
+    // assert_eq!(tree.get_height(), 3);
+    // assert_eq!(tree.num_nodes(), 9);
+
+    // // Compute hash for all leaves first
+    // for i in 0..5 {
+    //     let leaf_i = tree.get_leaf_node(i).unwrap();
+    //     let hash = tree.hash_node(leaf_i).unwrap();
+    //     println!("Hash of {}: {:?}", leaf_i, hash);
+    //     println!("Leaf {}: {:?}", i, leaf_i);
+    // }
+
+    // // Compute hash for nodes on level > 0 that's not root.
+    // for level in 1..tree.get_height() {
+    //     let level = tree.get_level(level);
+    //     for node in level.iter() {
+    //         let hash = tree.hash_node(node).unwrap();
+    //         println!("Hash of {}: {:?}", node, hash);
+    //         println!("Node {}: {:?}", node, node);
+    //     }
+    // }
+
+    // // Compute tree hash (hash of root node)
+    // let root = tree.get_root();
+    // let tree_hash = tree.hash_node(root);
+    // println!("Tree hash: {:?}", tree_hash);
 }


### PR DESCRIPTION
I pulled out `add_node` as the tree function used when adding people to an MLS group.
The test only calls the functions, there's nothing we can test here really. This should be used to generate test vectors though.