### PR TITLE
Remove Sender from Group API

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -17,7 +17,6 @@
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;
 use std::convert::*;
-use std::io::Write;
 
 #[derive(Debug)]
 pub enum CodecError {

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -354,6 +354,6 @@ fn test_extension_codec() {
         SUPPORTED_EXTENSIONS.to_vec(),
     );
     let extension = capabilities_extension.to_extension();
-    let bytes = extension.encode_detached().unwrap();
+    let _bytes = extension.encode_detached().unwrap();
     // let _dec = Extension::decode(&mut Cursor::new(&bytes));
 }

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -23,6 +23,9 @@ use crate::schedule::*;
 use crate::tree::{astree::*, index::*};
 use crate::utils::*;
 
+pub mod sender;
+use sender::*;
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct MLSPlaintext {
     pub group_id: GroupId,
@@ -419,75 +422,6 @@ impl Codec for MLSCiphertext {
             sender_data_nonce,
             encrypted_sender_data,
             ciphertext,
-        })
-    }
-}
-
-#[derive(PartialEq, Clone, Copy, Debug)]
-#[repr(u8)]
-pub enum SenderType {
-    Invalid = 0,
-    Member = 1,
-    Preconfigured = 2,
-    NewMember = 3,
-    Default = 255,
-}
-
-impl From<u8> for SenderType {
-    fn from(value: u8) -> Self {
-        match value {
-            0 => SenderType::Invalid,
-            1 => SenderType::Member,
-            2 => SenderType::Preconfigured,
-            3 => SenderType::NewMember,
-            _ => SenderType::Default,
-        }
-    }
-}
-
-impl Codec for SenderType {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        (*self as u8).encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        Ok(SenderType::from(u8::decode(cursor)?))
-    }
-}
-
-#[derive(PartialEq, Clone, Copy, Debug)]
-pub struct Sender {
-    pub sender_type: SenderType,
-    pub sender: LeafIndex,
-}
-
-impl Sender {
-    pub fn member(sender: LeafIndex) -> Self {
-        Sender {
-            sender_type: SenderType::Member,
-            sender,
-        }
-    }
-    pub fn as_leaf_index(&self) -> LeafIndex {
-        self.sender
-    }
-    pub fn as_node_index(self) -> NodeIndex {
-        NodeIndex::from(self.sender)
-    }
-}
-
-impl Codec for Sender {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.sender_type.encode(buffer)?;
-        self.sender.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let sender_type = SenderType::decode(cursor)?;
-        let sender = LeafIndex::from(u32::decode(cursor)?);
-        Ok(Sender {
-            sender_type,
-            sender,
         })
     }
 }

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -55,7 +55,7 @@ impl MLSPlaintext {
             epoch: context.epoch,
             sender,
             authenticated_data: authenticated_data.to_vec(),
-            content_type: ContentType::from(content.clone()),
+            content_type: ContentType::from(&content),
             content,
             signature: Signature::new_empty(),
         };
@@ -448,8 +448,8 @@ impl From<u8> for ContentType {
     }
 }
 
-impl From<MLSPlaintextContentType> for ContentType {
-    fn from(value: MLSPlaintextContentType) -> Self {
+impl From<&MLSPlaintextContentType> for ContentType {
+    fn from(value: &MLSPlaintextContentType) -> Self {
         match value {
             MLSPlaintextContentType::Application(_) => ContentType::Application,
             MLSPlaintextContentType::Proposal(_) => ContentType::Proposal,

--- a/src/framing/sender.rs
+++ b/src/framing/sender.rs
@@ -1,0 +1,97 @@
+//! Section  9. Message Framing
+//!
+//! ```text
+//! enum {
+//!     reserved(0),
+//!     application(1),
+//!     proposal(2),
+//!     commit(3),
+//!     (255)
+//! } ContentType;
+//!
+//! enum {
+//!     reserved(0),
+//!     member(1),
+//!     preconfigured(2),
+//!     new_member(3),
+//!     (255)
+//! } SenderType;
+//!
+//! struct {
+//!     SenderType sender_type;
+//!     uint32 sender;
+//! } Sender;
+//! ```
+//!
+
+use crate::codec::*;
+use crate::tree::index::*;
+
+#[derive(PartialEq, Clone, Copy, Debug)]
+#[repr(u8)]
+pub enum SenderType {
+    Invalid = 0,
+    Member = 1,
+    Preconfigured = 2,
+    NewMember = 3,
+    Default = 255,
+}
+
+impl From<u8> for SenderType {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => SenderType::Invalid,
+            1 => SenderType::Member,
+            2 => SenderType::Preconfigured,
+            3 => SenderType::NewMember,
+            _ => SenderType::Default,
+        }
+    }
+}
+
+impl Codec for SenderType {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        (*self as u8).encode(buffer)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        Ok(SenderType::from(u8::decode(cursor)?))
+    }
+}
+
+#[derive(PartialEq, Clone, Copy, Debug)]
+pub struct Sender {
+    pub sender_type: SenderType,
+    pub sender: LeafIndex,
+}
+
+impl Sender {
+    pub fn member(sender: LeafIndex) -> Self {
+        Sender {
+            sender_type: SenderType::Member,
+            sender,
+        }
+    }
+    pub fn as_leaf_index(&self) -> LeafIndex {
+        self.sender
+    }
+    pub fn as_node_index(self) -> NodeIndex {
+        NodeIndex::from(self.sender)
+    }
+}
+
+impl Codec for Sender {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.sender_type.encode(buffer)?;
+        self.sender.encode(buffer)?;
+        Ok(())
+    }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let sender_type = SenderType::decode(cursor)?;
+        let sender = LeafIndex::from(u32::decode(cursor)?);
+        Ok(Sender {
+            sender_type,
+            sender,
+        })
+    }
+}

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+#[derive(Debug)]
 pub enum WelcomeError {
     CiphersuiteMismatch = 100,
     JoinerSecretNotFound = 101,
@@ -26,6 +27,7 @@ pub enum WelcomeError {
     GroupInfoDecryptionFailure = 108,
 }
 
+#[derive(Debug)]
 pub enum ApplyCommitError {
     EpochMismatch = 200,
     WrongPlaintextContentType = 201,
@@ -38,6 +40,7 @@ pub enum ApplyCommitError {
     ConfirmationTagMismatch = 208,
 }
 
+#[derive(Debug)]
 pub enum CreateCommitError {
     CannotRemoveSelf = 300,
 }

--- a/src/group/mls_group/api.rs
+++ b/src/group/mls_group/api.rs
@@ -14,10 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use crate::framing::{sender::*, *};
+use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;
-use crate::messages::{proposals::*, *};
+use crate::messages::*;
 use crate::tree::{index::LeafIndex, node::*};
 
 pub trait Api: Sized {
@@ -42,28 +42,28 @@ pub trait Api: Sized {
         aad: &[u8],
         signature_key: &SignaturePrivateKey,
         joiner_key_package: KeyPackage,
-    ) -> (MLSPlaintext, Proposal);
+    ) -> MLSPlaintext;
     /// Create an `UpdateProposal`
     fn create_update_proposal(
         &self,
         aad: &[u8],
         signature_key: &SignaturePrivateKey,
         key_package: KeyPackage,
-    ) -> (MLSPlaintext, Proposal);
+    ) -> MLSPlaintext;
     /// Create a `RemoveProposal`
     fn create_remove_proposal(
         &self,
         aad: &[u8],
         signature_key: &SignaturePrivateKey,
         removed_index: LeafIndex,
-    ) -> (MLSPlaintext, Proposal);
+    ) -> MLSPlaintext;
     /// Create a `Commit` and an optional `Welcome`
     fn create_commit(
         &self,
         aad: &[u8],
         signature_key: &SignaturePrivateKey,
         key_package_bundle: KeyPackageBundle,
-        proposals: Vec<(MLSPlaintext, Proposal)>,
+        proposals: Vec<MLSPlaintext>,
         own_key_packages: Vec<KeyPackageBundle>,
         force_self_update: bool,
     ) -> CreateCommitResult;
@@ -72,7 +72,7 @@ pub trait Api: Sized {
     fn apply_commit(
         &mut self,
         mls_plaintext: MLSPlaintext,
-        proposals: Vec<(Sender, Proposal)>,
+        proposals: Vec<MLSPlaintext>,
         own_key_packages: Vec<KeyPackageBundle>,
     ) -> Result<(), ApplyCommitError>;
 

--- a/src/group/mls_group/api.rs
+++ b/src/group/mls_group/api.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use crate::framing::*;
+use crate::framing::{sender::*, *};
 use crate::group::*;
 use crate::key_packages::*;
 use crate::messages::{proposals::*, *};
@@ -63,7 +63,7 @@ pub trait Api: Sized {
         aad: &[u8],
         signature_key: &SignaturePrivateKey,
         key_package_bundle: KeyPackageBundle,
-        proposals: Vec<(Sender, Proposal)>,
+        proposals: Vec<(MLSPlaintext, Proposal)>,
         own_key_packages: Vec<KeyPackageBundle>,
         force_self_update: bool,
     ) -> CreateCommitResult;

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -22,162 +22,163 @@ use crate::key_packages::*;
 use crate::messages::*;
 use crate::utils::*;
 
-pub fn apply_commit(
-    group: &mut MlsGroup,
-    mls_plaintext: MLSPlaintext,
-    proposals: Vec<(Sender, Proposal)>,
-    own_key_packages: Vec<KeyPackageBundle>,
-) -> Result<(), ApplyCommitError> {
-    let ciphersuite = group.get_ciphersuite();
+impl MlsGroup {
+    pub(crate) fn apply_commit_internal(
+        &mut self,
+        mls_plaintext: MLSPlaintext,
+        proposals: Vec<(Sender, Proposal)>,
+        own_key_packages: Vec<KeyPackageBundle>,
+    ) -> Result<(), ApplyCommitError> {
+        let ciphersuite = self.get_ciphersuite();
 
-    // Verify epoch
-    if mls_plaintext.epoch != group.group_context.epoch {
-        return Err(ApplyCommitError::EpochMismatch);
-    }
-
-    // Create KeyPackageBundles
-    let mut pending_kpbs = vec![];
-    for kpb in own_key_packages {
-        let (pk, kp) = (
-            kpb.private_key,
-            kpb.key_package,
-        );
-        pending_kpbs.push(KeyPackageBundle::from_values(kp, pk));
-    }
-
-    // Extract Commit from MLSPlaintext
-    let (commit, confirmation_tag) = match mls_plaintext.content.clone() {
-        MLSPlaintextContentType::Commit((commit, confirmation)) => (commit, confirmation),
-        _ => return Err(ApplyCommitError::WrongPlaintextContentType),
-    };
-
-    // Organize proposals
-    let proposal_id_list = ProposalIDList {
-        updates: commit.updates.clone(),
-        removes: commit.removes.clone(),
-        adds: commit.adds.clone(),
-    };
-    let mut proposal_queue = ProposalQueue::new();
-    for (sender, proposal) in proposals {
-        let queued_proposal = QueuedProposal::new(proposal, sender.as_leaf_index(), None);
-        proposal_queue.add(queued_proposal, &ciphersuite);
-    }
-
-    // Create provisional tree and apply proposals
-    let mut provisional_tree = group.tree.borrow_mut();
-    let (membership_changes, _invited_members, group_removed) =
-        provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, pending_kpbs.clone());
-
-    // Check if we were removed from the group
-    if group_removed {
-        return Err(ApplyCommitError::SelfRemoved);
-    }
-
-    // Determine if Commit is own Commit
-    let sender = mls_plaintext.sender.sender;
-    let is_own_commit = mls_plaintext.sender.as_node_index() == provisional_tree.get_own_index(); // XXX: correct?
-
-    // Determine if Commit has a path
-    let commit_secret = if let Some(path) = commit.path.clone() {
-        // Verify KeyPackage and MLSPlaintext signature
-        let kp = &path.leaf_key_package;
-        if !kp.verify() {
-            return Err(ApplyCommitError::PathKeyPackageVerificationFailure);
+        // Verify epoch
+        if mls_plaintext.epoch != self.group_context.epoch {
+            return Err(ApplyCommitError::EpochMismatch);
         }
-        if !mls_plaintext.verify(&group.group_context, kp.get_credential()) {
-            return Err(ApplyCommitError::PlaintextSignatureFailure);
+
+        // Create KeyPackageBundles
+        let mut pending_kpbs = vec![];
+        for kpb in own_key_packages {
+            let (pk, kp) = (kpb.private_key, kpb.key_package);
+            pending_kpbs.push(KeyPackageBundle::from_values(kp, pk));
         }
-        if is_own_commit {
-            // Find the right KeyPackageBundle among the pending bundles
-            let own_kpb = pending_kpbs
-                .iter()
-                .find(|&kpb| kpb.get_key_package() == kp)
-                .unwrap();
-            let (commit_secret, _, _, _) = provisional_tree.update_own_leaf(
-                None,
-                own_kpb.clone(),
-                &group.group_context.serialize(),
-                false,
-            );
-            commit_secret
-        } else {
-            provisional_tree.update_direct_path(sender, &path, &group.group_context.serialize())
+
+        // Extract Commit from MLSPlaintext
+        let (commit, confirmation_tag) = match mls_plaintext.content.clone() {
+            MLSPlaintextContentType::Commit((commit, confirmation)) => (commit, confirmation),
+            _ => return Err(ApplyCommitError::WrongPlaintextContentType),
+        };
+
+        // Organize proposals
+        let proposal_id_list = ProposalIDList {
+            updates: commit.updates.clone(),
+            removes: commit.removes.clone(),
+            adds: commit.adds.clone(),
+        };
+        let mut proposal_queue = ProposalQueue::new();
+        for (sender, proposal) in proposals {
+            let queued_proposal = QueuedProposal::new(proposal, Sender::member(sender.as_leaf_index()), None);
+            proposal_queue.add(queued_proposal, &ciphersuite);
         }
-    } else {
-        if membership_changes.path_required() {
-            return Err(ApplyCommitError::RequiredPathNotFound);
+
+        // Create provisional tree and apply proposals
+        let mut provisional_tree = self.tree.borrow_mut();
+        let (membership_changes, _invited_members, group_removed) = provisional_tree
+            .apply_proposals(&proposal_id_list, proposal_queue, pending_kpbs.clone());
+
+        // Check if we were removed from the group
+        if group_removed {
+            return Err(ApplyCommitError::SelfRemoved);
         }
-        CommitSecret(zero(ciphersuite.hash_length()))
-    };
 
-    // Create provisional group state
-    let mut provisional_epoch = group.group_context.epoch;
-    provisional_epoch.increment();
+        // Determine if Commit is own Commit
+        let sender = mls_plaintext.sender.sender;
+        let is_own_commit =
+            mls_plaintext.sender.as_node_index() == provisional_tree.get_own_index(); // XXX: correct?
 
-    let confirmed_transcript_hash = update_confirmed_transcript_hash(
-        ciphersuite,
-        &MLSPlaintextCommitContent::new(&group.group_context, sender, commit.clone()),
-        &group.interim_transcript_hash,
-    );
-
-    let provisional_group_context = GroupContext {
-        group_id: group.group_context.group_id.clone(),
-        epoch: provisional_epoch,
-        tree_hash: provisional_tree.compute_tree_hash(),
-        confirmed_transcript_hash: confirmed_transcript_hash.clone(),
-    };
-
-    let mut provisional_epoch_secrets = group.epoch_secrets.clone();
-    provisional_epoch_secrets.get_new_epoch_secrets(
-        &ciphersuite,
-        commit_secret,
-        None,
-        &provisional_group_context,
-    );
-
-    let interim_transcript_hash =
-        update_interim_transcript_hash(&ciphersuite, &mls_plaintext, &confirmed_transcript_hash);
-
-    // Verify confirmation tag
-    if ConfirmationTag::new(
-        &ciphersuite,
-        &provisional_epoch_secrets.confirmation_key,
-        &confirmed_transcript_hash,
-    ) != confirmation_tag
-    {
-        return Err(ApplyCommitError::ConfirmationTagMismatch);
-    }
-
-    // Verify KeyPackage extensions
-    if let Some(path) = commit.path {
-        if !is_own_commit {
-            let parent_hash = provisional_tree.compute_parent_hash(NodeIndex::from(sender));
-            if let Some(received_parent_hash) = path
-                .leaf_key_package
-                .get_extension(ExtensionType::ParentHash)
-            {
-                if let ExtensionPayload::ParentHash(parent_hash_inner) = received_parent_hash {
-                    if parent_hash != parent_hash_inner.parent_hash {
-                        return Err(ApplyCommitError::ParentHashMismatch);
-                    }
-                }
+        // Determine if Commit has a path
+        let commit_secret = if let Some(path) = commit.path.clone() {
+            // Verify KeyPackage and MLSPlaintext signature
+            let kp = &path.leaf_key_package;
+            if !kp.verify() {
+                return Err(ApplyCommitError::PathKeyPackageVerificationFailure);
+            }
+            if !mls_plaintext.verify(&self.group_context, kp.get_credential()) {
+                return Err(ApplyCommitError::PlaintextSignatureFailure);
+            }
+            if is_own_commit {
+                // Find the right KeyPackageBundle among the pending bundles
+                let own_kpb = pending_kpbs
+                    .iter()
+                    .find(|&kpb| kpb.get_key_package() == kp)
+                    .unwrap();
+                let (commit_secret, _, _, _) = provisional_tree.update_own_leaf(
+                    None,
+                    own_kpb.clone(),
+                    &self.group_context.serialize(),
+                    false,
+                );
+                commit_secret
             } else {
-                return Err(ApplyCommitError::NoParentHashExtension);
+                provisional_tree.update_direct_path(sender, &path, &self.group_context.serialize())
+            }
+        } else {
+            if membership_changes.path_required() {
+                return Err(ApplyCommitError::RequiredPathNotFound);
+            }
+            CommitSecret(zero(ciphersuite.hash_length()))
+        };
+
+        // Create provisional group state
+        let mut provisional_epoch = self.group_context.epoch;
+        provisional_epoch.increment();
+
+        let confirmed_transcript_hash = update_confirmed_transcript_hash(
+            ciphersuite,
+            &MLSPlaintextCommitContent::new(&self.group_context, sender, commit.clone()),
+            &self.interim_transcript_hash,
+        );
+
+        let provisional_group_context = GroupContext {
+            group_id: self.group_context.group_id.clone(),
+            epoch: provisional_epoch,
+            tree_hash: provisional_tree.compute_tree_hash(),
+            confirmed_transcript_hash: confirmed_transcript_hash.clone(),
+        };
+
+        let mut provisional_epoch_secrets = self.epoch_secrets.clone();
+        provisional_epoch_secrets.get_new_epoch_secrets(
+            &ciphersuite,
+            commit_secret,
+            None,
+            &provisional_group_context,
+        );
+
+        let interim_transcript_hash = update_interim_transcript_hash(
+            &ciphersuite,
+            &mls_plaintext,
+            &confirmed_transcript_hash,
+        );
+
+        // Verify confirmation tag
+        if ConfirmationTag::new(
+            &ciphersuite,
+            &provisional_epoch_secrets.confirmation_key,
+            &confirmed_transcript_hash,
+        ) != confirmation_tag
+        {
+            return Err(ApplyCommitError::ConfirmationTagMismatch);
+        }
+
+        // Verify KeyPackage extensions
+        if let Some(path) = commit.path {
+            if !is_own_commit {
+                let parent_hash = provisional_tree.compute_parent_hash(NodeIndex::from(sender));
+                if let Some(received_parent_hash) = path
+                    .leaf_key_package
+                    .get_extension(ExtensionType::ParentHash)
+                {
+                    if let ExtensionPayload::ParentHash(parent_hash_inner) = received_parent_hash {
+                        if parent_hash != parent_hash_inner.parent_hash {
+                            return Err(ApplyCommitError::ParentHashMismatch);
+                        }
+                    }
+                } else {
+                    return Err(ApplyCommitError::NoParentHashExtension);
+                }
             }
         }
-    }
 
-    // Apply provisional tree and state to group
-    group.group_context = provisional_group_context;
-    group.epoch_secrets = provisional_epoch_secrets;
-    group.interim_transcript_hash = interim_transcript_hash;
-    group
-        .astree
-        .borrow_mut()
-        .set_size(provisional_tree.leaf_count());
-    group
-        .astree
-        .borrow_mut()
-        .set_application_secrets(&group.epoch_secrets.application_secret);
-    Ok(())
+        // Apply provisional tree and state to group
+        self.group_context = provisional_group_context;
+        self.epoch_secrets = provisional_epoch_secrets;
+        self.interim_transcript_hash = interim_transcript_hash;
+        self.astree
+            .borrow_mut()
+            .set_size(provisional_tree.leaf_count());
+        self.astree
+            .borrow_mut()
+            .set_application_secrets(&self.epoch_secrets.application_secret);
+        Ok(())
+    }
 }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -26,7 +26,7 @@ impl MlsGroup {
     pub(crate) fn apply_commit_internal(
         &mut self,
         mls_plaintext: MLSPlaintext,
-        proposals: Vec<(Sender, Proposal)>,
+        proposals: Vec<MLSPlaintext>,
         own_key_packages: Vec<KeyPackageBundle>,
     ) -> Result<(), ApplyCommitError> {
         let ciphersuite = self.get_ciphersuite();
@@ -56,8 +56,8 @@ impl MlsGroup {
             adds: commit.adds.clone(),
         };
         let mut proposal_queue = ProposalQueue::new();
-        for (sender, proposal) in proposals {
-            let queued_proposal = QueuedProposal::new(proposal, Sender::member(sender.as_leaf_index()), None);
+        for mls_plaintext in proposals {
+            let queued_proposal = QueuedProposal::new(mls_plaintext, None);
             proposal_queue.add(queued_proposal, &ciphersuite);
         }
 

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -26,219 +26,202 @@ use crate::tree::treemath;
 use crate::utils::*;
 use rayon::prelude::*;
 
-pub fn create_commit(
-    group: &MlsGroup,
-    aad: &[u8],
-    signature_key: &SignaturePrivateKey,
-    key_package_bundle: KeyPackageBundle,
-    proposals: Vec<(Sender, Proposal)>,
-    own_key_packages: Vec<KeyPackageBundle>,
-    force_group_update: bool,
-) -> CreateCommitResult {
-    let ciphersuite = group.get_ciphersuite();
-    let (private_key, key_package) = (
-        key_package_bundle.private_key,
-        key_package_bundle.key_package,
-    );
-
-    // Create KeyPackageBundles
-    let mut pending_kpbs = vec![];
-    for kpb in own_key_packages {
-        let (pk, kp) = (
-            kpb.private_key,
-            kpb.key_package,
+impl MlsGroup {
+    pub(crate) fn create_commit_internal(
+        &self,
+        aad: &[u8],
+        signature_key: &SignaturePrivateKey,
+        key_package_bundle: KeyPackageBundle,
+        proposals: Vec<(MLSPlaintext, Proposal)>,
+        own_key_packages: Vec<KeyPackageBundle>,
+        force_self_update: bool,
+    ) -> CreateCommitResult {
+        let ciphersuite = self.get_ciphersuite();
+        let (private_key, key_package) = (
+            key_package_bundle.private_key,
+            key_package_bundle.key_package,
         );
-        pending_kpbs.push(KeyPackageBundle::from_values(kp, pk));
-    }
+        // Create KeyPackageBundles
+        let mut pending_kpbs = vec![];
+        for kpb in own_key_packages {
+            let (pk, kp) = (kpb.private_key, kpb.key_package);
+            pending_kpbs.push(KeyPackageBundle::from_values(kp, pk));
+        }
+        // Organize proposals
+        let mut proposal_queue = ProposalQueue::new();
+        for (mls_plaintext, proposal) in proposals {
+            let queued_proposal = QueuedProposal::new(proposal, mls_plaintext.sender, None);
+            proposal_queue.add(queued_proposal, &ciphersuite);
+        }
+        
+        // TODO Dedup proposals
+        let proposal_id_list = proposal_queue.get_commit_lists(&ciphersuite);
+        
+        let mut provisional_tree = self.tree.borrow_mut();
 
-    // Organize proposals
-    let mut proposal_queue = ProposalQueue::new();
-    for (sender, proposal) in proposals {
-        let queued_proposal = QueuedProposal::new(proposal, sender.as_leaf_index(), None);
-        proposal_queue.add(queued_proposal, &ciphersuite);
-    }
+        // Apply proposals to tree
+        let (membership_changes, invited_members, group_removed) =
+            provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, pending_kpbs);
+        if group_removed {
+            return Err(CreateCommitError::CannotRemoveSelf);
+        }
+        // Determine if Commit needs path field
+        let path_required = membership_changes.path_required() || force_self_update;
 
-    // TODO Dedup proposals
-    let proposal_id_list = proposal_queue.get_commit_lists(&ciphersuite);
-
-    // Create provisional tree
-    let mut provisional_tree = group.tree.borrow_mut();
-
-    // Apply proposals to tree
-    let (membership_changes, invited_members, group_removed) =
-        provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, pending_kpbs);
-    if group_removed {
-        return Err(CreateCommitError::CannotRemoveSelf);
-    }
-
-    // Determine if Commit needs path field
-    let path_required = membership_changes.path_required() || force_group_update;
-
-    let (commit_secret, path, path_secrets_option, key_package_bundle_option) = if path_required {
-        // If path is eeded, compute path values
-        let (commit_secret, kpb, path_option, path_secrets) = provisional_tree.update_own_leaf(
-            Some(signature_key),
-            KeyPackageBundle::from_values(key_package, private_key),
-            &group.group_context.serialize(),
-            true,
+        let (commit_secret, path, path_secrets_option, key_package_bundle_option) = if path_required
+        {
+            // If path is eeded, compute path values
+            let (commit_secret, kpb, path_option, path_secrets) = provisional_tree.update_own_leaf(
+                Some(signature_key),
+                KeyPackageBundle::from_values(key_package, private_key),
+                &self.group_context.serialize(),
+                true,
+            );
+            (commit_secret, path_option, path_secrets, Some(kpb))
+        } else {
+            // If path is not needed, return empty commit secret
+            let commit_secret = CommitSecret(zero(self.get_ciphersuite().hash_length()));
+            (commit_secret, None, None, None)
+        };
+        let return_kpb_option = if let Some(kpb) = key_package_bundle_option {
+            Some((kpb.get_private_key().clone(), kpb.get_key_package().clone()))
+        } else {
+            None
+        };
+        // Create commit message
+        let commit = Commit {
+            updates: proposal_id_list.updates,
+            removes: proposal_id_list.removes,
+            adds: proposal_id_list.adds,
+            path,
+        };
+        // Create provisional group state
+        let mut provisional_epoch = self.group_context.epoch;
+        provisional_epoch.increment();
+        let confirmed_transcript_hash = update_confirmed_transcript_hash(
+            self.get_ciphersuite(),
+            &MLSPlaintextCommitContent::new(
+                &self.group_context,
+                self.get_sender_index(),
+                commit.clone(),
+            ),
+            &self.interim_transcript_hash,
         );
-        (commit_secret, path_option, path_secrets, Some(kpb))
-    } else {
-        // If path is not needed, return empty commit secret
-        let commit_secret = CommitSecret(zero(group.get_ciphersuite().hash_length()));
-        (commit_secret, None, None, None)
-    };
-    let return_kpb_option = if let Some(kpb) = key_package_bundle_option {
-        Some((kpb.get_private_key().clone(), kpb.get_key_package().clone()))
-    } else {
-        None
-    };
-
-    // Create commit message
-    let commit = Commit {
-        updates: proposal_id_list.updates,
-        removes: proposal_id_list.removes,
-        adds: proposal_id_list.adds,
-        path,
-    };
-
-    // Create provisional group state
-    let mut provisional_epoch = group.group_context.epoch;
-    provisional_epoch.increment();
-
-    let confirmed_transcript_hash = update_confirmed_transcript_hash(
-        group.get_ciphersuite(),
-        &MLSPlaintextCommitContent::new(
-            &group.group_context,
-            group.get_sender_index(),
-            commit.clone(),
-        ),
-        &group.interim_transcript_hash,
-    );
-
-    let provisional_group_context = GroupContext {
-        group_id: group.group_context.group_id.clone(),
-        epoch: provisional_epoch,
-        tree_hash: provisional_tree.compute_tree_hash(),
-        confirmed_transcript_hash: confirmed_transcript_hash.clone(),
-    };
-
-    let mut provisional_epoch_secrets = group.epoch_secrets.clone();
-    let epoch_secret = provisional_epoch_secrets.get_new_epoch_secrets(
-        &ciphersuite,
-        commit_secret,
-        None,
-        &provisional_group_context,
-    );
-
-    // Compute confirmation tag
-    let confirmation_tag = ConfirmationTag::new(
-        &ciphersuite,
-        &provisional_epoch_secrets.confirmation_key,
-        &confirmed_transcript_hash,
-    );
-
-    // Create MLSPlaintext
-    let content = MLSPlaintextContentType::Commit((commit, confirmation_tag.clone()));
-    let mls_plaintext = MLSPlaintext::new(
-        ciphersuite,
-        group.get_sender_index(),
-        aad,
-        content,
-        signature_key,
-        &group.get_context(),
-    );
-
-    // Check if new members were added an create welcome message
-    // TODO: Add support for extensions
-    if !membership_changes.adds.is_empty() {
-        let public_tree = RatchetTreeExtension::new(provisional_tree.public_key_tree());
-        let ratchet_tree_extension = public_tree.to_extension();
-        let tree_hash = ciphersuite.hash(&ratchet_tree_extension.extension_data);
-
-        // Create GroupInfo object
-        let interim_transcript_hash = update_interim_transcript_hash(
+        let provisional_group_context = GroupContext {
+            group_id: self.group_context.group_id.clone(),
+            epoch: provisional_epoch,
+            tree_hash: provisional_tree.compute_tree_hash(),
+            confirmed_transcript_hash: confirmed_transcript_hash.clone(),
+        };
+        let mut provisional_epoch_secrets = self.epoch_secrets.clone();
+        let epoch_secret = provisional_epoch_secrets.get_new_epoch_secrets(
             &ciphersuite,
-            &mls_plaintext,
+            commit_secret,
+            None,
+            &provisional_group_context,
+        );
+        // Compute confirmation tag
+        let confirmation_tag = ConfirmationTag::new(
+            &ciphersuite,
+            &provisional_epoch_secrets.confirmation_key,
             &confirmed_transcript_hash,
         );
-        let mut group_info = GroupInfo {
-            group_id: provisional_group_context.group_id.clone(),
-            epoch: provisional_group_context.epoch,
-            tree_hash,
-            confirmed_transcript_hash,
-            interim_transcript_hash,
-            extensions: vec![],
-            confirmation_tag: confirmation_tag.as_slice(),
-            signer_index: group.get_sender_index(),
-            signature: Signature::new_empty(),
-        };
-        group_info.signature = group_info.sign(ciphersuite, signature_key);
-
-        // Encrypt GroupInfo object
-        let (welcome_key, welcome_nonce) = compute_welcome_key_nonce(ciphersuite, &epoch_secret);
-
-        let encrypted_group_info = ciphersuite
-            .aead_seal(
-                &group_info.encode_detached().unwrap(),
-                &[],
-                &welcome_key,
-                &welcome_nonce,
-            )
-            .unwrap();
-
-        // Create group secrets
-        let mut plaintext_secrets = vec![];
-        for (index, add_proposal) in invited_members.clone() {
-            let key_package = add_proposal.key_package;
-            let key_package_hash = ciphersuite.hash(&key_package.encode_detached().unwrap());
-            let path_secret = if path_required {
-                let common_ancestor = treemath::common_ancestor(index, provisional_tree.get_own_index());
-                let dirpath = treemath::dirpath_root(
-                    provisional_tree.get_own_index(),
-                    provisional_tree.leaf_count(),
-                );
-                let position = dirpath.iter().position(|&x| x == common_ancestor).unwrap();
-                let path_secrets = path_secrets_option.clone().unwrap();
-                let path_secret = path_secrets[position].clone();
-                Some(PathSecret { path_secret })
-            } else {
-                None
+        // Create MLSPlaintext
+        let content = MLSPlaintextContentType::Commit((commit, confirmation_tag.clone()));
+        let mls_plaintext = MLSPlaintext::new(
+            ciphersuite,
+            self.get_sender_index(),
+            aad,
+            content,
+            signature_key,
+            &self.get_context(),
+        );
+        // Check if new members were added an create welcome message
+        // TODO: Add support for extensions
+        if !membership_changes.adds.is_empty() {
+            let public_tree = RatchetTreeExtension::new(provisional_tree.public_key_tree());
+            let ratchet_tree_extension = public_tree.to_extension();
+            let tree_hash = ciphersuite.hash(&ratchet_tree_extension.extension_data);
+            // Create GroupInfo object
+            let interim_transcript_hash = update_interim_transcript_hash(
+                &ciphersuite,
+                &mls_plaintext,
+                &confirmed_transcript_hash,
+            );
+            let mut group_info = GroupInfo {
+                group_id: provisional_group_context.group_id.clone(),
+                epoch: provisional_group_context.epoch,
+                tree_hash,
+                confirmed_transcript_hash,
+                interim_transcript_hash,
+                extensions: vec![],
+                confirmation_tag: confirmation_tag.as_slice(),
+                signer_index: self.get_sender_index(),
+                signature: Signature::new_empty(),
             };
-
-            let group_secrets = GroupSecrets {
-                joiner_secret: epoch_secret.clone(),
-                path_secret,
+            group_info.signature = group_info.sign(ciphersuite, signature_key);
+            // Encrypt GroupInfo object
+            let (welcome_key, welcome_nonce) =
+                compute_welcome_key_nonce(ciphersuite, &epoch_secret);
+            let encrypted_group_info = ciphersuite
+                .aead_seal(
+                    &group_info.encode_detached().unwrap(),
+                    &[],
+                    &welcome_key,
+                    &welcome_nonce,
+                )
+                .unwrap();
+            // Create group secrets
+            let mut plaintext_secrets = vec![];
+            for (index, add_proposal) in invited_members.clone() {
+                let key_package = add_proposal.key_package;
+                let key_package_hash = ciphersuite.hash(&key_package.encode_detached().unwrap());
+                let path_secret = if path_required {
+                    let common_ancestor =
+                        treemath::common_ancestor(index, provisional_tree.get_own_index());
+                    let dirpath = treemath::dirpath_root(
+                        provisional_tree.get_own_index(),
+                        provisional_tree.leaf_count(),
+                    );
+                    let position = dirpath.iter().position(|&x| x == common_ancestor).unwrap();
+                    let path_secrets = path_secrets_option.clone().unwrap();
+                    let path_secret = path_secrets[position].clone();
+                    Some(PathSecret { path_secret })
+                } else {
+                    None
+                };
+                let group_secrets = GroupSecrets {
+                    joiner_secret: epoch_secret.clone(),
+                    path_secret,
+                };
+                let group_secrets_bytes = group_secrets.encode_detached().unwrap();
+                plaintext_secrets.push((
+                    key_package.get_hpke_init_key().clone(),
+                    group_secrets_bytes,
+                    key_package_hash,
+                ));
+            }
+            // Encrypt group secrets
+            let secrets = plaintext_secrets
+                .par_iter()
+                .map(|(init_key, bytes, key_package_hash)| {
+                    let encrypted_group_secrets = ciphersuite.hpke_seal(init_key, &[], &[], bytes);
+                    EncryptedGroupSecrets {
+                        key_package_hash: key_package_hash.clone(),
+                        encrypted_group_secrets,
+                    }
+                })
+                .collect();
+            // Create welcome message
+            let welcome = Welcome {
+                version: ProtocolVersion::Mls10,
+                cipher_suite: self.ciphersuite,
+                secrets,
+                encrypted_group_info,
             };
-            let group_secrets_bytes = group_secrets.encode_detached().unwrap();
-            plaintext_secrets.push((
-                key_package.get_hpke_init_key().clone(),
-                group_secrets_bytes,
-                key_package_hash,
-            ));
+            Ok((mls_plaintext, Some(welcome), return_kpb_option))
+        } else {
+            Ok((mls_plaintext, None, return_kpb_option))
         }
-
-        // Encrypt group secrets
-        let secrets = plaintext_secrets
-            .par_iter()
-            .map(|(init_key, bytes, key_package_hash)| {
-                let encrypted_group_secrets = ciphersuite.hpke_seal(init_key, &[], &[], bytes);
-                EncryptedGroupSecrets {
-                    key_package_hash: key_package_hash.clone(),
-                    encrypted_group_secrets,
-                }
-            })
-            .collect();
-
-        // Create welcome message
-        let welcome = Welcome {
-            version: ProtocolVersion::Mls10,
-            cipher_suite: group.ciphersuite,
-            secrets,
-            encrypted_group_info,
-        };
-        Ok((mls_plaintext, Some(welcome), return_kpb_option))
-    } else {
-        Ok((mls_plaintext, None, return_kpb_option))
     }
 }

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -57,6 +57,7 @@ impl MlsGroup {
         // TODO Dedup proposals
         let proposal_id_list = proposal_queue.get_commit_lists(&ciphersuite);
         
+        let sender_index = self.get_sender_index();
         let mut provisional_tree = self.tree.borrow_mut();
 
         // Apply proposals to tree
@@ -102,7 +103,7 @@ impl MlsGroup {
             self.get_ciphersuite(),
             &MLSPlaintextCommitContent::new(
                 &self.group_context,
-                self.get_sender_index(),
+                sender_index,
                 commit.clone(),
             ),
             &self.interim_transcript_hash,
@@ -130,7 +131,7 @@ impl MlsGroup {
         let content = MLSPlaintextContentType::Commit((commit, confirmation_tag.clone()));
         let mls_plaintext = MLSPlaintext::new(
             ciphersuite,
-            self.get_sender_index(),
+            sender_index,
             aad,
             content,
             signature_key,
@@ -156,7 +157,7 @@ impl MlsGroup {
                 interim_transcript_hash,
                 extensions: vec![],
                 confirmation_tag: confirmation_tag.as_slice(),
-                signer_index: self.get_sender_index(),
+                signer_index: sender_index,
                 signature: Signature::new_empty(),
             };
             group_info.signature = group_info.sign(ciphersuite, signature_key);

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -32,7 +32,7 @@ impl MlsGroup {
         aad: &[u8],
         signature_key: &SignaturePrivateKey,
         key_package_bundle: KeyPackageBundle,
-        proposals: Vec<(MLSPlaintext, Proposal)>,
+        proposals: Vec<MLSPlaintext>,
         own_key_packages: Vec<KeyPackageBundle>,
         force_self_update: bool,
     ) -> CreateCommitResult {
@@ -49,8 +49,8 @@ impl MlsGroup {
         }
         // Organize proposals
         let mut proposal_queue = ProposalQueue::new();
-        for (mls_plaintext, proposal) in proposals {
-            let queued_proposal = QueuedProposal::new(proposal, mls_plaintext.sender, None);
+        for mls_plaintext in proposals {
+            let queued_proposal = QueuedProposal::new(mls_plaintext, None);
             proposal_queue.add(queued_proposal, &ciphersuite);
         }
         

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -21,7 +21,7 @@ mod new_from_welcome;
 
 use crate::ciphersuite::*;
 use crate::codec::*;
-use crate::framing::*;
+use crate::framing::{sender::*, *};
 use crate::group::*;
 use crate::key_packages::*;
 use crate::messages::{proposals::*, *};
@@ -29,9 +29,6 @@ use crate::schedule::*;
 use crate::tree::{astree::*, index::*, node::*, *};
 
 pub use api::*;
-use apply_commit::*;
-use create_commit::*;
-use new_from_welcome::*;
 
 use std::cell::{Ref, RefCell};
 
@@ -79,7 +76,7 @@ impl Api for MlsGroup {
         nodes_option: Option<Vec<Option<Node>>>,
         kpb: KeyPackageBundle,
     ) -> Result<Self, WelcomeError> {
-        new_from_welcome(welcome, nodes_option, kpb)
+        Self::new_from_welcome_internal(welcome, nodes_option, kpb)
     }
 
     // Create handshake messages
@@ -149,12 +146,11 @@ impl Api for MlsGroup {
         aad: &[u8],
         signature_key: &SignaturePrivateKey,
         key_package_bundle: KeyPackageBundle,
-        proposals: Vec<(Sender, Proposal)>,
+        proposals: Vec<(MLSPlaintext, Proposal)>,
         own_key_packages: Vec<KeyPackageBundle>,
         force_self_update: bool,
     ) -> CreateCommitResult {
-        create_commit(
-            self,
+        self.create_commit_internal(
             aad,
             signature_key,
             key_package_bundle,
@@ -171,7 +167,7 @@ impl Api for MlsGroup {
         proposals: Vec<(Sender, Proposal)>,
         own_key_packages: Vec<KeyPackageBundle>,
     ) -> Result<(), ApplyCommitError> {
-        apply_commit(self, mls_plaintext, proposals, own_key_packages)
+        self.apply_commit_internal(mls_plaintext, proposals, own_key_packages)
     }
 
     // Create application message

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -22,164 +22,167 @@ use crate::messages::*;
 use crate::schedule::*;
 use crate::tree::{astree::*, index::*, node::*, treemath, *};
 
-pub fn new_from_welcome(
-    welcome: Welcome,
-    nodes_option: Option<Vec<Option<Node>>>,
-    key_package_bundle: KeyPackageBundle,
-) -> Result<MlsGroup, WelcomeError> {
-    let ciphersuite = welcome.cipher_suite;
-    let (private_key, key_package) = (
-        key_package_bundle.private_key,
-        key_package_bundle.key_package,
-    );
+impl MlsGroup {
+    pub(crate) fn new_from_welcome_internal(
+        welcome: Welcome,
+        nodes_option: Option<Vec<Option<Node>>>,
+        key_package_bundle: KeyPackageBundle,
+    ) -> Result<Self, WelcomeError> {
+        let ciphersuite = welcome.cipher_suite;
+        let (private_key, key_package) = (
+            key_package_bundle.private_key,
+            key_package_bundle.key_package,
+        );
 
-    // Find key_package in welcome secrets
-    let egs =
-        if let Some(egs) = find_key_package_from_welcome_secrets(&key_package, &welcome.secrets) {
+        // Find key_package in welcome secrets
+        let egs = if let Some(egs) =
+            Self::find_key_package_from_welcome_secrets(&key_package, &welcome.secrets)
+        {
             egs
         } else {
             return Err(WelcomeError::JoinerSecretNotFound);
         };
-    if &ciphersuite != key_package.get_cipher_suite() {
-        return Err(WelcomeError::CiphersuiteMismatch);
-    }
+        if &ciphersuite != key_package.get_cipher_suite() {
+            return Err(WelcomeError::CiphersuiteMismatch);
+        }
 
-    // Compute keys to decrypt GroupInfo
-    let (group_info, group_secrets) = decrypt_group_info(
-        &ciphersuite,
-        &egs,
-        &private_key,
-        &welcome.encrypted_group_info,
-    )?;
-
-    // Build the ratchet tree
-    // TODO: check the extensions to see if the tree is in there
-    let nodes = if let Some(nodes) = nodes_option {
-        nodes
-    } else {
-        return Err(WelcomeError::MissingRatchetTree);
-    };
-
-    let mut tree = if let Some(tree) = RatchetTree::new_from_nodes(
-        ciphersuite,
-        KeyPackageBundle::from_values(key_package, private_key),
-        &nodes,
-    ) {
-        tree
-    } else {
-        return Err(WelcomeError::JoinerNotInTree);
-    };
-
-    // Verify tree hash
-    if tree.compute_tree_hash() != &group_info.tree_hash[..] {
-        return Err(WelcomeError::TreeHashMismatch);
-    }
-
-    // Verify GroupInfo signature
-    let signer_node = tree.nodes[NodeIndex::from(group_info.signer_index).as_usize()].clone();
-    let signer_key_package = signer_node.key_package.unwrap();
-    let payload = group_info.unsigned_payload().unwrap();
-    if !signer_key_package
-        .get_credential()
-        .verify(&payload, &group_info.signature)
-    {
-        return Err(WelcomeError::InvalidGroupInfoSignature);
-    }
-
-    // Verify ratchet tree
-    if !RatchetTree::verify_integrity(&ciphersuite, &nodes) {
-        return Err(WelcomeError::InvalidRatchetTree);
-    }
-
-    // Compute path secrets
-    // TODO: check if path_secret has to be optional
-    if let Some(path_secret) = group_secrets.path_secret {
-        let common_ancestor = treemath::common_ancestor(
-            tree.get_own_index(),
-            NodeIndex::from(group_info.signer_index),
-        );
-        let common_path = treemath::dirpath_root(common_ancestor, tree.leaf_count());
-        let (path_secrets, _commit_secret) = OwnLeaf::continue_path_secrets(
+        // Compute keys to decrypt GroupInfo
+        let (group_info, group_secrets) = Self::decrypt_group_info(
             &ciphersuite,
-            &path_secret.path_secret,
-            common_path.len(),
-        );
-        let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
-        tree.merge_keypairs(&keypairs, &common_path);
+            &egs,
+            &private_key,
+            &welcome.encrypted_group_info,
+        )?;
 
-        let mut path_keypairs = PathKeypairs::new();
-        path_keypairs.add(&keypairs, &common_path);
-        tree.own_leaf.path_keypairs = path_keypairs;
-    }
+        // Build the ratchet tree
+        // TODO: check the extensions to see if the tree is in there
+        let nodes = if let Some(nodes) = nodes_option {
+            nodes
+        } else {
+            return Err(WelcomeError::MissingRatchetTree);
+        };
 
-    // Compute state
-    let group_context = GroupContext {
-        group_id: group_info.group_id,
-        epoch: group_info.epoch,
-        tree_hash: tree.compute_tree_hash(),
-        confirmed_transcript_hash: group_info.confirmed_transcript_hash,
-    };
-    let epoch_secrets =
-        EpochSecrets::derive_epoch_secrets(&ciphersuite, &group_secrets.joiner_secret, vec![]);
-    let astree = ASTree::new(&epoch_secrets.application_secret, tree.leaf_count());
+        let mut tree = if let Some(tree) = RatchetTree::new_from_nodes(
+            ciphersuite,
+            KeyPackageBundle::from_values(key_package, private_key),
+            &nodes,
+        ) {
+            tree
+        } else {
+            return Err(WelcomeError::JoinerNotInTree);
+        };
 
-    // Verify confirmation tag
-    if ConfirmationTag::new(
-        &ciphersuite,
-        &epoch_secrets.confirmation_key,
-        &group_context.confirmed_transcript_hash,
-    ) != ConfirmationTag(group_info.confirmation_tag)
-    {
-        Err(WelcomeError::ConfirmationTagMismatch)
-    } else {
-        Ok(MlsGroup {
-            ciphersuite: welcome.cipher_suite,
-            group_context,
-            generation: 0,
-            epoch_secrets,
-            astree: RefCell::new(astree),
-            tree: RefCell::new(tree),
-            interim_transcript_hash: group_info.interim_transcript_hash,
-        })
-    }
-}
+        // Verify tree hash
+        if tree.compute_tree_hash() != &group_info.tree_hash[..] {
+            return Err(WelcomeError::TreeHashMismatch);
+        }
 
-// Helper functions
+        // Verify GroupInfo signature
+        let signer_node = tree.nodes[NodeIndex::from(group_info.signer_index).as_usize()].clone();
+        let signer_key_package = signer_node.key_package.unwrap();
+        let payload = group_info.unsigned_payload().unwrap();
+        if !signer_key_package
+            .get_credential()
+            .verify(&payload, &group_info.signature)
+        {
+            return Err(WelcomeError::InvalidGroupInfoSignature);
+        }
 
-fn find_key_package_from_welcome_secrets(
-    key_package: &KeyPackage,
-    welcome_secrets: &[EncryptedGroupSecrets],
-) -> Option<EncryptedGroupSecrets> {
-    for egs in welcome_secrets {
-        if key_package.hash() == egs.key_package_hash {
-            return Some(egs.clone());
+        // Verify ratchet tree
+        if !RatchetTree::verify_integrity(&ciphersuite, &nodes) {
+            return Err(WelcomeError::InvalidRatchetTree);
+        }
+
+        // Compute path secrets
+        // TODO: check if path_secret has to be optional
+        if let Some(path_secret) = group_secrets.path_secret {
+            let common_ancestor = treemath::common_ancestor(
+                tree.get_own_index(),
+                NodeIndex::from(group_info.signer_index),
+            );
+            let common_path = treemath::dirpath_root(common_ancestor, tree.leaf_count());
+            let (path_secrets, _commit_secret) = OwnLeaf::continue_path_secrets(
+                &ciphersuite,
+                &path_secret.path_secret,
+                common_path.len(),
+            );
+            let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
+            tree.merge_keypairs(&keypairs, &common_path);
+
+            let mut path_keypairs = PathKeypairs::new();
+            path_keypairs.add(&keypairs, &common_path);
+            tree.own_leaf.path_keypairs = path_keypairs;
+        }
+
+        // Compute state
+        let group_context = GroupContext {
+            group_id: group_info.group_id,
+            epoch: group_info.epoch,
+            tree_hash: tree.compute_tree_hash(),
+            confirmed_transcript_hash: group_info.confirmed_transcript_hash,
+        };
+        let epoch_secrets =
+            EpochSecrets::derive_epoch_secrets(&ciphersuite, &group_secrets.joiner_secret, vec![]);
+        let astree = ASTree::new(&epoch_secrets.application_secret, tree.leaf_count());
+
+        // Verify confirmation tag
+        if ConfirmationTag::new(
+            &ciphersuite,
+            &epoch_secrets.confirmation_key,
+            &group_context.confirmed_transcript_hash,
+        ) != ConfirmationTag(group_info.confirmation_tag)
+        {
+            Err(WelcomeError::ConfirmationTagMismatch)
+        } else {
+            Ok(MlsGroup {
+                ciphersuite: welcome.cipher_suite,
+                group_context,
+                generation: 0,
+                epoch_secrets,
+                astree: RefCell::new(astree),
+                tree: RefCell::new(tree),
+                interim_transcript_hash: group_info.interim_transcript_hash,
+            })
         }
     }
-    None
-}
 
-fn decrypt_group_info(
-    ciphersuite: &Ciphersuite,
-    encrypted_group_secrets: &EncryptedGroupSecrets,
-    private_key: &HPKEPrivateKey,
-    encrypted_group_info: &[u8],
-) -> Result<(GroupInfo, GroupSecrets), WelcomeError> {
-    let group_secrets_bytes = ciphersuite.hpke_open(
-        &encrypted_group_secrets.encrypted_group_secrets,
-        &private_key,
-        &[],
-        &[],
-    );
-    let group_secrets = GroupSecrets::decode(&mut Cursor::new(&group_secrets_bytes)).unwrap();
-    let (welcome_key, welcome_nonce) =
-        compute_welcome_key_nonce(ciphersuite, &group_secrets.joiner_secret);
-    let group_info_bytes =
-        match ciphersuite.aead_open(encrypted_group_info, &[], &welcome_key, &welcome_nonce) {
-            Ok(bytes) => bytes,
-            Err(_) => return Err(WelcomeError::GroupInfoDecryptionFailure),
-        };
-    Ok((
-        GroupInfo::from_bytes(&group_info_bytes).unwrap(),
-        group_secrets,
-    ))
+    // Helper functions
+
+    fn find_key_package_from_welcome_secrets(
+        key_package: &KeyPackage,
+        welcome_secrets: &[EncryptedGroupSecrets],
+    ) -> Option<EncryptedGroupSecrets> {
+        for egs in welcome_secrets {
+            if key_package.hash() == egs.key_package_hash {
+                return Some(egs.clone());
+            }
+        }
+        None
+    }
+
+    fn decrypt_group_info(
+        ciphersuite: &Ciphersuite,
+        encrypted_group_secrets: &EncryptedGroupSecrets,
+        private_key: &HPKEPrivateKey,
+        encrypted_group_info: &[u8],
+    ) -> Result<(GroupInfo, GroupSecrets), WelcomeError> {
+        let group_secrets_bytes = ciphersuite.hpke_open(
+            &encrypted_group_secrets.encrypted_group_secrets,
+            &private_key,
+            &[],
+            &[],
+        );
+        let group_secrets = GroupSecrets::decode(&mut Cursor::new(&group_secrets_bytes)).unwrap();
+        let (welcome_key, welcome_nonce) =
+            compute_welcome_key_nonce(ciphersuite, &group_secrets.joiner_secret);
+        let group_info_bytes =
+            match ciphersuite.aead_open(encrypted_group_info, &[], &welcome_key, &welcome_nonce) {
+                Ok(bytes) => bytes,
+                Err(_) => return Err(WelcomeError::GroupInfoDecryptionFailure),
+            };
+        Ok((
+            GroupInfo::from_bytes(&group_info_bytes).unwrap(),
+            group_secrets,
+        ))
+    }
 }

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -31,7 +31,7 @@ fn test_codec() {
         credential,
         None,
     );
-    let enc = kpb.encode_detached().unwrap();
+    let _enc = kpb.encode_detached().unwrap();
     // let kp = KeyPackage::decode(&mut Cursor::new(&enc)).unwrap();
     // assert_eq!(kpb.key_package, kp);
 }

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -1,6 +1,6 @@
 use crate::ciphersuite::*;
 use crate::codec::*;
-use crate::framing::*;
+use crate::framing::sender::*;
 use crate::key_packages::*;
 use crate::tree::index::LeafIndex;
 use std::collections::HashMap;
@@ -116,10 +116,6 @@ impl Codec for ProposalID {
         encode_vec(VecSize::VecU8, buffer, &self.value)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let value = decode_vec(VecSize::VecU8, cursor)?;
-    //     Ok(ProposalID { value })
-    // }
 }
 
 #[derive(Eq, PartialEq, Hash, Copy, Clone)]
@@ -138,12 +134,6 @@ impl Codec for ShortProposalID {
         encode_vec(VecSize::VecU8, buffer, &self.0)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let value = decode_vec(VecSize::VecU8, cursor)?;
-    //     let mut inner = [0u8; 32];
-    //     inner.copy_from_slice(&value[..32]);
-    //     Ok(ShortProposalID(inner))
-    // }
 }
 
 #[derive(Clone)]
@@ -154,33 +144,23 @@ pub struct QueuedProposal {
 }
 
 impl QueuedProposal {
-    pub fn new(proposal: Proposal, sender: LeafIndex, own_kpb: Option<KeyPackageBundle>) -> Self {
+    pub fn new(proposal: Proposal, sender: Sender, own_kpb: Option<KeyPackageBundle>) -> Self {
         Self {
             proposal,
-            sender: Sender::member(sender),
+            sender,
             own_kpb,
         }
     }
 }
 
-impl Codec for QueuedProposal {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.proposal.encode(buffer)?;
-        self.sender.encode(buffer)?;
-        self.own_kpb.encode(buffer)?;
-        Ok(())
-    }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let proposal = Proposal::decode(cursor)?;
-    //     let sender = Sender::decode(cursor)?;
-    //     let own_kpb = Option::<KeyPackageBundle>::decode(cursor)?;
-    //     Ok(QueuedProposal {
-    //         proposal,
-    //         sender,
-    //         own_kpb,
-    //     })
-    // }
-}
+// impl Codec for QueuedProposal {
+//     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+//         self.proposal.encode(buffer)?;
+//         self.sender.encode(buffer)?;
+//         self.own_kpb.encode(buffer)?;
+//         Ok(())
+//     }
+// }
 
 #[derive(Default, Clone)]
 pub struct ProposalQueue {
@@ -221,16 +201,12 @@ impl ProposalQueue {
     }
 }
 
-impl Codec for ProposalQueue {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.tuples.encode(buffer)?;
-        Ok(())
-    }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let tuples = HashMap::<ShortProposalID, (ProposalID, QueuedProposal)>::decode(cursor)?;
-    //     Ok(ProposalQueue { tuples })
-    // }
-}
+// impl Codec for ProposalQueue {
+//     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+//         self.tuples.encode(buffer)?;
+//         Ok(())
+//     }
+// }
 
 #[derive(Clone)]
 pub struct ProposalIDList {
@@ -249,10 +225,6 @@ impl Codec for AddProposal {
         self.key_package.encode(buffer)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let key_package = KeyPackage::decode(cursor)?;
-    //     Ok(AddProposal { key_package })
-    // }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -265,10 +237,6 @@ impl Codec for UpdateProposal {
         self.key_package.encode(buffer)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let key_package = KeyPackage::decode(cursor)?;
-    //     Ok(UpdateProposal { key_package })
-    // }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -281,8 +249,4 @@ impl Codec for RemoveProposal {
         self.removed.encode(buffer)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let removed = u32::decode(cursor)?;
-    //     Ok(RemoveProposal { removed })
-    // }
 }

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -1,8 +1,7 @@
 use crate::ciphersuite::*;
 use crate::codec::*;
-use crate::framing::sender::*;
+use crate::framing::{sender::*, *};
 use crate::key_packages::*;
-use crate::tree::index::LeafIndex;
 use std::collections::HashMap;
 
 #[derive(Clone, Copy, Debug)]
@@ -144,10 +143,15 @@ pub struct QueuedProposal {
 }
 
 impl QueuedProposal {
-    pub fn new(proposal: Proposal, sender: Sender, own_kpb: Option<KeyPackageBundle>) -> Self {
+    pub fn new(mls_plaintext: MLSPlaintext, own_kpb: Option<KeyPackageBundle>) -> Self {
+        debug_assert!(mls_plaintext.content_type == ContentType::Proposal);
+        let proposal = match mls_plaintext.content {
+            MLSPlaintextContentType::Proposal(p) => p,
+            _ => panic!("API misuses. Only proposal can end up in the proposal queue"),
+        };
         Self {
             proposal,
-            sender,
+            sender: mls_plaintext.sender,
             own_kpb,
         }
     }

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -46,7 +46,8 @@ fn basic_group_setup() {
 
     // Alice creates a group
     let group_id = [1, 2, 3, 4];
-    let mut group_alice_1234 = MlsGroup::new(&group_id, ciphersuite, alice_key_package_bundle);
+    // FIXME: We should never have to clone the key package bundle
+    let mut group_alice_1234 = MlsGroup::new(&group_id, ciphersuite, alice_key_package_bundle.clone());
 
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
@@ -54,14 +55,17 @@ fn basic_group_setup() {
         &alice_identity.get_signature_key_pair().get_private_key(),
         bob_key_package.clone(),
     );
-    // group_alice_1234.create_commit(
-    //     group_aad,
-    //     &alice_identity.get_signature_key_pair().get_private_key(),
-    //     alice_key_package_bundle,
-    //     vec![(bob, bob_add_proposal)],
-    //     vec![alice_key_package_bundle],
-    //     true,
-    // );
+    let commit = match group_alice_1234.create_commit(
+        group_aad,
+        &alice_identity.get_signature_key_pair().get_private_key(),
+        alice_key_package_bundle.clone(),
+        vec![bob_add_proposal],
+        vec![alice_key_package_bundle],
+        true,
+    ) {
+        Ok(c) => c,
+        Err(e) => panic!("Error creating commit: {:?}", e),
+    };
 }
 
 /*

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -7,6 +7,7 @@ use maelstrom::key_packages::*;
 fn basic_group_setup() {
     let ciphersuite =
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+    let group_aad = b"Alice's test group";
 
     // Define identities
     let alice_identity = Identity::new(ciphersuite, "Alice".into());
@@ -49,15 +50,15 @@ fn basic_group_setup() {
 
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
-        &[],
+        group_aad,
         &alice_identity.get_signature_key_pair().get_private_key(),
         bob_key_package.clone(),
     );
     // group_alice_1234.create_commit(
-    //     &[],
+    //     group_aad,
     //     &alice_identity.get_signature_key_pair().get_private_key(),
     //     alice_key_package_bundle,
-    //     vec![bob_add_proposal],
+    //     vec![(bob, bob_add_proposal)],
     //     vec![alice_key_package_bundle],
     //     true,
     // );


### PR DESCRIPTION
`Sender` should not be used in the group API. This PR removes it from all public group APIs.

Make sure to review this with `Hide whitespace changes` enabled.

Fixes #20 