### PR TITLE
tree reorg

### DIFF
--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -366,39 +366,18 @@ impl HPKEPrivateKey {
 impl HPKEKeyPair {
     /// Derive a new key pair for the HPKE KEM with the given input key material.
     pub(crate) fn derive(ikm: &[u8], ciphersuite: &Ciphersuite) -> Self {
-        let (pk, sk) = Hpke::new(
+        let key_pair = Hpke::new(
             Mode::Base,
             ciphersuite.hpke_kem,
             ciphersuite.hpke_kdf,
             ciphersuite.hpke_aead,
         )
-        .derive_keypair(ikm);
+        .derive_key_pair(ikm);
         Self {
-            private_key: HPKEPrivateKey { value: sk },
-            public_key: HPKEPublicKey { value: pk },
+            private_key: HPKEPrivateKey { value: key_pair.get_private_key_ref().as_slice().to_vec() },
+            public_key: HPKEPublicKey { value: key_pair.get_public_key_ref().as_slice().to_vec() },
         }
     }
-
-    /// Build a new HPKE key pair from the given `bytes`.
-    pub(crate) fn from_slice(bytes: &[u8], ciphersuite: &Ciphersuite) -> Self {
-        let private_key = HPKEPrivateKey::from_slice(bytes);
-        let public_key = private_key.public_key(ciphersuite.hpke_kem);
-        Self {
-            private_key,
-            public_key,
-        }
-    }
-
-    /// Get a reference to the private key.
-    pub(crate) fn get_private_key_ref(&self) -> &HPKEPrivateKey {
-        &self.private_key
-    }
-
-    /// Get a reference to the public key.
-    pub(crate) fn get_public_key_ref(&self) -> &HPKEPublicKey {
-        &self.public_key
-    }
-
 
     /// Get the private key.
     pub(crate) fn get_private_key(&self) -> HPKEPrivateKey {
@@ -408,6 +387,7 @@ impl HPKEKeyPair {
     /// Get the public key.
     pub(crate) fn get_public_key(&self) -> HPKEPublicKey {
         self.public_key.clone()
+    }
 
     fn into(&self) -> RealHPKEKeyPair {
         RealHPKEKeyPair::new(

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -364,13 +364,23 @@ impl HPKEKeyPair {
     }
 
     /// Get a reference to the private key.
-    pub(crate) fn get_private_key(&self) -> &HPKEPrivateKey {
+    pub(crate) fn get_private_key_ref(&self) -> &HPKEPrivateKey {
         &self.private_key
     }
 
     /// Get a reference to the public key.
-    pub(crate) fn get_public_key(&self) -> &HPKEPublicKey {
+    pub(crate) fn get_public_key_ref(&self) -> &HPKEPublicKey {
         &self.public_key
+    }
+
+    /// Get the private key.
+    pub(crate) fn get_private_key(&self) -> HPKEPrivateKey {
+        self.private_key.clone()
+    }
+
+    /// Get the public key.
+    pub(crate) fn get_public_key(&self) -> HPKEPublicKey {
+        self.public_key.clone()
     }
 }
 

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -338,6 +338,21 @@ impl HPKEPrivateKey {
 }
 
 impl HPKEKeyPair {
+    /// Derive a new key pair for the HPKE KEM with the given input key material.
+    pub(crate) fn derive(ikm: &[u8], ciphersuite: &Ciphersuite) -> Self {
+        let (pk, sk) = Hpke::new(
+            Mode::Base,
+            ciphersuite.hpke_kem,
+            ciphersuite.hpke_kdf,
+            ciphersuite.hpke_aead,
+        )
+        .derive_keypair(ikm);
+        Self {
+            private_key: HPKEPrivateKey { value: sk },
+            public_key: HPKEPublicKey { value: pk },
+        }
+    }
+
     /// Build a new HPKE key pair from the given `bytes`.
     pub(crate) fn from_slice(bytes: &[u8], ciphersuite: &Ciphersuite) -> Self {
         let private_key = HPKEPrivateKey::from_slice(bytes);

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -92,15 +92,19 @@ impl MlsGroup {
                     .iter()
                     .find(|&kpb| kpb.get_key_package() == kp)
                     .unwrap();
-                let (commit_secret, _, _, _) = provisional_tree.update_own_leaf(
-                    None,
-                    own_kpb.clone(),
-                    &self.group_context.serialize(),
-                    false,
-                );
+                let (commit_secret, _, _, _) = provisional_tree
+                    .update_own_leaf(
+                        None,
+                        own_kpb.clone(),
+                        &self.group_context.serialize(),
+                        false,
+                    )
+                    .unwrap();
                 commit_secret
             } else {
-                provisional_tree.update_direct_path(sender, &path, &self.group_context.serialize())
+                provisional_tree
+                    .update_direct_path(sender, &path, &self.group_context.serialize())
+                    .unwrap()
             }
         } else {
             if membership_changes.path_required() {

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -180,7 +180,7 @@ impl MlsGroup {
                 let path_secret = if path_required {
                     let common_ancestor =
                         treemath::common_ancestor(index, provisional_tree.get_own_index());
-                    let dirpath = treemath::dirpath_root(
+                    let dirpath = treemath::direct_path_root(
                         provisional_tree.get_own_index(),
                         provisional_tree.leaf_count(),
                     );

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -53,10 +53,8 @@ impl MlsGroup {
             let queued_proposal = QueuedProposal::new(mls_plaintext, None);
             proposal_queue.add(queued_proposal, &ciphersuite);
         }
-        
         // TODO Dedup proposals
         let proposal_id_list = proposal_queue.get_commit_lists(&ciphersuite);
-        
         let sender_index = self.get_sender_index();
         let mut provisional_tree = self.tree.borrow_mut();
 
@@ -72,12 +70,14 @@ impl MlsGroup {
         let (commit_secret, path, path_secrets_option, key_package_bundle_option) = if path_required
         {
             // If path is eeded, compute path values
-            let (commit_secret, kpb, path_option, path_secrets) = provisional_tree.update_own_leaf(
-                Some(signature_key),
-                KeyPackageBundle::from_values(key_package, private_key),
-                &self.group_context.serialize(),
-                true,
-            );
+            let (commit_secret, kpb, path_option, path_secrets) = provisional_tree
+                .update_own_leaf(
+                    Some(signature_key),
+                    KeyPackageBundle::from_values(key_package, private_key),
+                    &self.group_context.serialize(),
+                    true,
+                )
+                .unwrap();
             (commit_secret, path_option, path_secrets, Some(kpb))
         } else {
             // If path is not needed, return empty commit secret
@@ -101,11 +101,7 @@ impl MlsGroup {
         provisional_epoch.increment();
         let confirmed_transcript_hash = update_confirmed_transcript_hash(
             self.get_ciphersuite(),
-            &MLSPlaintextCommitContent::new(
-                &self.group_context,
-                sender_index,
-                commit.clone(),
-            ),
+            &MLSPlaintextCommitContent::new(&self.group_context, sender_index, commit.clone()),
             &self.interim_transcript_hash,
         );
         let provisional_group_context = GroupContext {

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -20,7 +20,9 @@ use crate::group::{mls_group::*, *};
 use crate::key_packages::*;
 use crate::messages::*;
 use crate::schedule::*;
-use crate::tree::{astree::*, index::*, node::*, treemath, *};
+use crate::tree::{
+    astree::*, index::*, node::*, own_leaf::OwnLeaf, path_key_pairs::PathKeypairs, treemath, *,
+};
 
 impl MlsGroup {
     pub(crate) fn new_from_welcome_internal(
@@ -101,9 +103,10 @@ impl MlsGroup {
                 NodeIndex::from(group_info.signer_index),
             );
             let common_path = treemath::dirpath_root(common_ancestor, tree.leaf_count());
-            let (path_secrets, _commit_secret) = OwnLeaf::continue_path_secrets(
+            let (path_secrets, _commit_secret) = OwnLeaf::generate_path_secrets(
                 &ciphersuite,
                 &path_secret.path_secret,
+                false,
                 common_path.len(),
             );
             let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
@@ -111,7 +114,7 @@ impl MlsGroup {
 
             let mut path_keypairs = PathKeypairs::new();
             path_keypairs.add(&keypairs, &common_path);
-            tree.own_leaf.path_keypairs = path_keypairs;
+            tree.get_own_leaf_mut().set_path_key_pairs(path_keypairs);
         }
 
         // Compute state

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -103,7 +103,7 @@ impl MlsGroup {
                 NodeIndex::from(group_info.signer_index),
             );
             let common_path = treemath::dirpath_root(common_ancestor, tree.leaf_count());
-            let (path_secrets, _commit_secret) = OwnLeaf::generate_path_secrets(
+            let path_secrets = OwnLeaf::generate_path_secrets(
                 &ciphersuite,
                 &path_secret.path_secret,
                 false,
@@ -112,7 +112,7 @@ impl MlsGroup {
             let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
             tree.merge_keypairs(&keypairs, &common_path);
 
-            let mut path_keypairs = PathKeypairs::new();
+            let mut path_keypairs = PathKeypairs::default();
             path_keypairs.add(&keypairs, &common_path);
             tree.get_own_leaf_mut().set_path_key_pairs(path_keypairs);
         }

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -103,7 +103,7 @@ impl MlsGroup {
                 tree.get_own_index(),
                 NodeIndex::from(group_info.signer_index),
             );
-            let common_path = treemath::dirpath_root(common_ancestor, tree.leaf_count());
+            let common_path = treemath::direct_path_root(common_ancestor, tree.leaf_count());
             let path_secrets = OwnLeaf::generate_path_secrets(
                 &ciphersuite,
                 &path_secret.path_secret,

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -91,12 +91,13 @@ impl MlsGroup {
         }
 
         // Verify ratchet tree
+        // TODO: #35 Why does this get the nodes? Shouldn't `new_from_nodes` consume the nodes?
         if !RatchetTree::verify_integrity(&ciphersuite, &nodes) {
             return Err(WelcomeError::InvalidRatchetTree);
         }
 
         // Compute path secrets
-        // TODO: check if path_secret has to be optional
+        // TODO: #36 check if path_secret has to be optional
         if let Some(path_secret) = group_secrets.path_secret {
             let common_ancestor = treemath::common_ancestor(
                 tree.get_own_index(),

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -106,7 +106,7 @@ impl MlsGroup {
             let path_secrets = OwnLeaf::generate_path_secrets(
                 &ciphersuite,
                 &path_secret.path_secret,
-                false,
+                false /* non-leaf */,
                 common_path.len(),
             );
             let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -21,7 +21,7 @@ use crate::key_packages::*;
 use crate::messages::*;
 use crate::schedule::*;
 use crate::tree::{
-    astree::*, index::*, node::*, own_leaf::OwnLeaf, path_key_pairs::PathKeypairs, treemath, *,
+    astree::*, index::*, node::*, own_leaf::OwnLeaf, path_keys::PathKeys, treemath, *,
 };
 
 impl MlsGroup {
@@ -112,9 +112,9 @@ impl MlsGroup {
             let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
             tree.merge_keypairs(&keypairs, &common_path);
 
-            let mut path_keypairs = PathKeypairs::default();
-            path_keypairs.add(&keypairs, &common_path);
-            tree.get_own_leaf_mut().set_path_key_pairs(path_keypairs);
+            let mut path_keys = PathKeys::default();
+            path_keys.add(&keypairs, &common_path);
+            tree.get_own_leaf_mut().set_path_key_pairs(path_keys);
         }
 
         // Compute state

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -122,7 +122,7 @@ impl Codec for ConfirmationTag {
     // }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Default)]
 pub struct CommitSecret(pub Vec<u8>);
 
 impl CommitSecret {

--- a/src/tree/codec.rs
+++ b/src/tree/codec.rs
@@ -48,7 +48,6 @@ impl Codec for RatchetTree {
     // }
 }
 
-
 impl Codec for DirectPathNode {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.public_key.encode(buffer)?;

--- a/src/tree/codec.rs
+++ b/src/tree/codec.rs
@@ -29,36 +29,6 @@ impl Codec for Node {
     // }
 }
 
-impl Codec for PathKeypairs {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU32, buffer, &self.keypairs)?;
-        Ok(())
-    }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let keypairs = decode_vec(VecSize::VecU32, cursor)?;
-    //     Ok(PathKeypairs { keypairs })
-    // }
-}
-
-impl Codec for OwnLeaf {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.kpb.encode(buffer)?;
-        self.node_index.as_u32().encode(buffer)?;
-        self.path_keypairs.encode(buffer)?;
-        Ok(())
-    }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let kpb = KeyPackageBundle::decode(cursor)?;
-    //     let node_index = NodeIndex::from(u32::decode(cursor)?);
-    //     let path_keypairs = PathKeypairs::decode(cursor)?;
-    //     Ok(OwnLeaf {
-    //         kpb,
-    //         node_index,
-    //         path_keypairs,
-    //     })
-    // }
-}
-
 impl Codec for RatchetTree {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         self.ciphersuite.encode(buffer)?;
@@ -78,29 +48,6 @@ impl Codec for RatchetTree {
     // }
 }
 
-impl<'a> Codec for ParentNodeHashInput<'a> {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.node_index.encode(buffer)?;
-        self.parent_node.encode(buffer)?;
-        encode_vec(VecSize::VecU8, buffer, &self.left_hash)?;
-        encode_vec(VecSize::VecU8, buffer, &self.right_hash)?;
-        Ok(())
-    }
-    fn decode(_cursor: &mut Cursor) -> Result<Self, CodecError> {
-        unimplemented!()
-    }
-}
-
-impl<'a> Codec for LeafNodeHashInput<'a> {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.node_index.as_u32().encode(buffer)?;
-        self.key_package.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(_cursor: &mut Cursor) -> Result<Self, CodecError> {
-        unimplemented!()
-    }
-}
 
 impl Codec for DirectPathNode {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {

--- a/src/tree/hash_input.rs
+++ b/src/tree/hash_input.rs
@@ -1,0 +1,99 @@
+//! 7.5. Tree Hashes
+//!
+//! ```text
+//! struct {
+//!     uint8 present;
+//!     select (present) {
+//!         case 0: struct{};
+//!         case 1: T value;
+//!     }
+//! } optional<T>;
+//!
+//! struct {
+//!     HPKEPublicKey public_key;
+//!     uint32 unmerged_leaves<0..2^32-1>;
+//!     opaque parent_hash<0..255>;
+//! } ParentNode;
+//!
+//! struct {
+//!     uint32 node_index;
+//!     optional<ParentNode> parent_node;
+//!     opaque left_hash<0..255>;
+//!     opaque right_hash<0..255>;
+//! } ParentNodeHashInput;
+//!
+//! struct {
+//!     uint32 node_index;
+//!     optional<KeyPackage> key_package;
+//! } LeafNodeHashInput;
+//! ```
+//!
+
+use super::index::NodeIndex;
+use super::node::ParentNode;
+use crate::ciphersuite::Ciphersuite;
+use crate::codec::{encode_vec, Codec, CodecError, VecSize};
+use crate::key_packages::KeyPackage;
+
+pub struct ParentNodeHashInput<'a> {
+    node_index: u32,
+    parent_node: &'a Option<ParentNode>,
+    left_hash: &'a [u8],
+    right_hash: &'a [u8],
+}
+
+impl<'a> ParentNodeHashInput<'a> {
+    pub fn new(
+        node_index: u32,
+        parent_node: &'a Option<ParentNode>,
+        left_hash: &'a [u8],
+        right_hash: &'a [u8],
+    ) -> Self {
+        Self {
+            node_index,
+            parent_node,
+            left_hash,
+            right_hash,
+        }
+    }
+    pub fn hash(&self, ciphersuite: &Ciphersuite) -> Vec<u8> {
+        let payload = self.encode_detached().unwrap();
+        ciphersuite.hash(&payload)
+    }
+}
+
+pub struct LeafNodeHashInput<'a> {
+    node_index: &'a NodeIndex,
+    key_package: &'a Option<KeyPackage>,
+}
+
+impl<'a> LeafNodeHashInput<'a> {
+    pub fn new(node_index: &'a NodeIndex, key_package: &'a Option<KeyPackage>) -> Self {
+        Self {
+            node_index,
+            key_package,
+        }
+    }
+    pub fn hash(&self, ciphersuite: &Ciphersuite) -> Vec<u8> {
+        let payload = self.encode_detached().unwrap();
+        ciphersuite.hash(&payload)
+    }
+}
+
+impl<'a> Codec for ParentNodeHashInput<'a> {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.node_index.encode(buffer)?;
+        self.parent_node.encode(buffer)?;
+        encode_vec(VecSize::VecU8, buffer, &self.left_hash)?;
+        encode_vec(VecSize::VecU8, buffer, &self.right_hash)?;
+        Ok(())
+    }
+}
+
+impl<'a> Codec for LeafNodeHashInput<'a> {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.node_index.as_u32().encode(buffer)?;
+        self.key_package.encode(buffer)?;
+        Ok(())
+    }
+}

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -1,6 +1,6 @@
 use crate::codec::*;
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Default)]
 pub struct NodeIndex(u32);
 
 impl NodeIndex {

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -1,6 +1,6 @@
 use crate::codec::*;
 
-#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Default)]
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Default, Hash)]
 pub struct NodeIndex(u32);
 
 impl NodeIndex {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -42,8 +42,10 @@ use path_keys::*;
 
 // Internal tree tests
 mod test_astree;
-mod test_treemath;
 mod test_own_leaf;
+mod test_path_keys;
+mod test_treemath;
+mod test_util;
 
 #[derive(Debug)]
 pub struct RatchetTree {
@@ -715,4 +717,5 @@ pub struct DirectPath {
 pub enum TreeError {
     InvalidArguments,
     NoneError,
+    DuplicateIndex,
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -52,6 +52,7 @@ pub struct RatchetTree {
 }
 
 impl RatchetTree {
+    /// Create a new empty `RatchetTree`.
     pub(crate) fn new(ciphersuite: Ciphersuite, kpb: KeyPackageBundle) -> RatchetTree {
         let own_leaf = OwnLeaf::new(kpb.private_key, NodeIndex::from(0u32), PathKeys::default());
         let nodes = vec![Node {
@@ -107,19 +108,11 @@ impl RatchetTree {
             }
         }
 
-        let secret = kpb.get_private_key().as_slice();
+        // Build OwnLeaf
         let direct_path =
             treemath::direct_path_root(own_index, NodeIndex::from(nodes.len()).into());
-        let path_secrets = OwnLeaf::generate_path_secrets(
-            &ciphersuite,
-            secret,
-            true, /* leaf */
-            direct_path.len(),
-        );
-        let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
-        let mut path_keys = PathKeys::default();
-        path_keys.add(&keypairs, &direct_path);
-        let own_leaf = OwnLeaf::new(kpb.private_key, own_index, path_keys);
+        let own_leaf = OwnLeaf::new_raw(&ciphersuite, own_index, kpb.private_key, &direct_path);
+
         Some(RatchetTree {
             ciphersuite,
             nodes,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -43,6 +43,7 @@ use path_keys::*;
 // Internal tree tests
 mod test_astree;
 mod test_treemath;
+mod test_own_leaf;
 
 #[derive(Debug)]
 pub struct RatchetTree {
@@ -255,7 +256,7 @@ impl RatchetTree {
             .hpke_open(hpke_ciphertext, &private_key, group_context, &[]);
         self.own_leaf
             .generate_path_secrets(&self.ciphersuite, Some(&secret), common_path.len());
-        self.own_leaf.generate_commit_secret(&self.ciphersuite);
+        self.own_leaf.generate_commit_secret(&self.ciphersuite)?;
         let sender_path_offset = sender_dirpath.len() - common_path.len();
 
         // Update OwnLeaf path keys
@@ -277,8 +278,8 @@ impl RatchetTree {
         }
 
         // Merge new nodes into the tree
-        self.merge_direct_path_keys(direct_path, sender_dirpath);
-        self.merge_public_keys(&new_path_public_keys, &common_path);
+        self.merge_direct_path_keys(direct_path, sender_dirpath)?;
+        self.merge_public_keys(&new_path_public_keys, &common_path)?;
         self.nodes[NodeIndex::from(sender).as_usize()] =
             Node::new_leaf(Some(direct_path.leaf_key_package.clone()));
         self.compute_parent_hash(NodeIndex::from(sender));
@@ -314,7 +315,7 @@ impl RatchetTree {
             kpb.private_key.clone(),
             &direct_path_root,
         )?;
-        self.merge_public_keys(&new_public_keys, &direct_path_root);
+        self.merge_public_keys(&new_public_keys, &direct_path_root)?;
 
         // Check if we need to add the parent hash extension and re-sign the KeyPackage
         let key_package_bundle = match signature_key_option {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -121,7 +121,7 @@ impl RatchetTree {
         // Build OwnLeaf
         let direct_path =
             treemath::direct_path_root(own_index, NodeIndex::from(nodes.len()).into());
-        let (own_leaf, public_keys) =
+        let (own_leaf, _public_keys) =
             OwnLeaf::new_raw(&ciphersuite, own_index, kpb.private_key, &direct_path)?;
         // FIXME: the public keys get los here.
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -30,7 +30,7 @@ pub(crate) mod hash_input;
 pub(crate) mod index;
 pub(crate) mod node;
 pub(crate) mod own_leaf;
-pub(crate) mod path_key_pairs;
+pub(crate) mod path_keys;
 pub(crate) mod sender_ratchet;
 pub(crate) mod treemath;
 
@@ -38,7 +38,7 @@ use hash_input::*;
 use index::*;
 use node::*;
 use own_leaf::*;
-use path_key_pairs::*;
+use path_keys::*;
 
 // Internal tree tests
 mod test_astree;
@@ -56,7 +56,7 @@ impl RatchetTree {
         let own_leaf = OwnLeaf::new(
             kpb.private_key,
             NodeIndex::from(0u32),
-            PathKeypairs::default(),
+            PathKeys::default(),
         );
         let nodes = vec![Node {
             node_type: NodeType::Leaf,
@@ -114,9 +114,9 @@ impl RatchetTree {
             dirpath.len(),
         );
         let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
-        let mut path_keypairs = PathKeypairs::default();
-        path_keypairs.add(&keypairs, &dirpath);
-        let own_leaf = OwnLeaf::new(kpb.private_key, index, path_keypairs);
+        let mut path_keys = PathKeys::default();
+        path_keys.add(&keypairs, &dirpath);
+        let own_leaf = OwnLeaf::new(kpb.private_key, index, path_keys);
         Some(RatchetTree {
             ciphersuite,
             nodes,
@@ -237,7 +237,6 @@ impl RatchetTree {
                 .get_path_key_pairs()
                 .get(common_ancestor_copath_index)
                 .unwrap()
-                .get_private_key()
         };
 
         // Compute the common path between the common ancestor and the root
@@ -325,7 +324,7 @@ impl RatchetTree {
         // Update own leaf node with the new values
         self.nodes[own_index.as_usize()] =
             Node::new_leaf(Some(key_package_bundle.get_key_package().clone()));
-        let mut path_keypairs = PathKeypairs::default();
+        let mut path_keypairs = PathKeys::default();
         path_keypairs.add(&keypairs, &dirpath_root);
         let own_leaf = OwnLeaf::new(
             key_package_bundle.private_key.clone(),
@@ -480,7 +479,7 @@ impl RatchetTree {
                     .find(|&kpb| kpb.get_key_package() == &update_proposal.key_package)
                     .unwrap();
                 self.own_leaf =
-                    OwnLeaf::new(own_kpb.private_key.clone(), index, PathKeypairs::default());
+                    OwnLeaf::new(own_kpb.private_key.clone(), index, PathKeys::default());
             }
         }
         for r in proposal_id_list.removes.iter() {

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -24,6 +24,8 @@ impl From<u8> for NodeType {
 #[derive(Debug, PartialEq, Clone)]
 pub struct Node {
     pub node_type: NodeType,
+    // The node only holds public values.
+    // The private HPKE keys are stored in the `OwnLeaf`.
     pub key_package: Option<KeyPackage>,
     pub node: Option<ParentNode>,
 }

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -24,6 +24,26 @@ pub(crate) struct OwnLeaf {
 }
 
 impl OwnLeaf {
+    /// Generate a new `OwnLeaf` based on the input values.
+    pub(crate) fn new_raw(
+        ciphersuite: &Ciphersuite,
+        node_index: NodeIndex,
+        hpke_private_key: HPKEPrivateKey,
+        direct_path: &[NodeIndex],
+    ) -> Self {
+        let path_secrets = OwnLeaf::generate_path_secrets(
+            &ciphersuite,
+            hpke_private_key.as_slice(),
+            true, /* leaf */
+            direct_path.len(),
+        );
+        let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
+        let mut path_keys = PathKeys::default();
+        path_keys.add(&keypairs, &direct_path);
+        Self::new(hpke_private_key, node_index, path_keys)
+    }
+
+    /// Generate a new `OwnLeaf` and populate it with pre-computed values.
     pub(crate) fn new(
         hpke_private_key: HPKEPrivateKey,
         node_index: NodeIndex,

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -2,7 +2,7 @@
 //! belongs to the current client.
 //!
 
-// TODO: Functions should operate on `self`.
+// TODO: #26 Functions should operate on `self`.
 
 use super::{index::NodeIndex, path_key_pairs::PathKeypairs};
 use crate::ciphersuite::{Ciphersuite, HPKEKeyPair, HPKEPrivateKey};

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -4,8 +4,8 @@
 
 // TODO: #26 Functions should operate on `self`.
 
-use super::{index::NodeIndex, path_keys::PathKeys};
-use crate::ciphersuite::{Ciphersuite, HPKEKeyPair, HPKEPrivateKey};
+use super::{index::NodeIndex, path_keys::PathKeys, TreeError};
+use crate::ciphersuite::{Ciphersuite, HPKEKeyPair, HPKEPrivateKey, HPKEPublicKey};
 use crate::codec::{Codec, CodecError};
 use crate::messages::CommitSecret;
 use crate::schedule::hkdf_expand_label;
@@ -21,26 +21,48 @@ pub(crate) struct OwnLeaf {
 
     // A vector of HPKEKeyPairs in the path from this leaf.
     path_keys: PathKeys,
+
+    // Commit secret.
+    commit_secret: CommitSecret,
+
+    // Path secrets.
+    // The first entry here must be the hpke_private_key.
+    path_secrets: Vec<Vec<u8>>,
 }
 
 impl OwnLeaf {
+    /// Create a minimal `OwnLeaf` setting only the private key.
+    pub(crate) fn from_private_key(
+        node_index: NodeIndex,
+        hpke_private_key: HPKEPrivateKey,
+    ) -> Self {
+        Self {
+            node_index,
+            hpke_private_key,
+            path_keys: PathKeys::default(),
+            commit_secret: CommitSecret::default(),
+            path_secrets: Vec::default(),
+        }
+    }
+
     /// Generate a new `OwnLeaf` based on the input values.
     pub(crate) fn new_raw(
         ciphersuite: &Ciphersuite,
         node_index: NodeIndex,
         hpke_private_key: HPKEPrivateKey,
         direct_path: &[NodeIndex],
-    ) -> Self {
-        let path_secrets = OwnLeaf::generate_path_secrets(
-            &ciphersuite,
-            hpke_private_key.as_slice(),
-            true, /* leaf */
-            direct_path.len(),
-        );
-        let keypairs = OwnLeaf::generate_path_keypairs(&ciphersuite, &path_secrets);
-        let mut path_keys = PathKeys::default();
-        path_keys.add(&keypairs, &direct_path);
-        Self::new(hpke_private_key, node_index, path_keys)
+    ) -> Result<(Self, Vec<HPKEPublicKey>), TreeError> {
+        let mut out = Self::from_private_key(node_index, hpke_private_key);
+
+        // Compute path secrets.
+        out.generate_path_secrets(&ciphersuite, None, direct_path.len());
+
+        // Compute commit secret.
+        out.generate_commit_secret(ciphersuite)?;
+
+        // Generate key pairs and return.
+        let public_keys = out.generate_path_keypairs(ciphersuite, direct_path)?;
+        Ok((out, public_keys))
     }
 
     /// Generate a new `OwnLeaf` and populate it with pre-computed values.
@@ -48,11 +70,15 @@ impl OwnLeaf {
         hpke_private_key: HPKEPrivateKey,
         node_index: NodeIndex,
         path_keys: PathKeys,
+        commit_secret: CommitSecret,
+        path_secrets: Vec<Vec<u8>>,
     ) -> Self {
         Self {
             hpke_private_key,
             node_index,
             path_keys,
+            commit_secret,
+            path_secrets,
         }
     }
 
@@ -64,14 +90,20 @@ impl OwnLeaf {
     pub(crate) fn get_node_index(&self) -> NodeIndex {
         self.node_index
     }
-    pub(crate) fn get_path_key_pairs(&self) -> &PathKeys {
+    pub(crate) fn get_path_keys(&self) -> &PathKeys {
         &self.path_keys
     }
-    pub(crate) fn get_path_key_pairs_mut(&mut self) -> &mut PathKeys {
+    pub(crate) fn get_path_keys_mut(&mut self) -> &mut PathKeys {
         &mut self.path_keys
     }
     pub(crate) fn set_path_key_pairs(&mut self, new_key_pairs: PathKeys) {
         self.path_keys = new_key_pairs;
+    }
+    pub(crate) fn get_commit_secret(&self) -> CommitSecret {
+        self.commit_secret.clone()
+    }
+    pub(crate) fn get_path_secrets(&self) -> &[Vec<u8>] {
+        &self.path_secrets
     }
 
     /// Generate `n` path secrets with the given `start_secret`.
@@ -82,18 +114,17 @@ impl OwnLeaf {
     /// path_secret[n] = DeriveSecret(path_secret[n-1], "path")
     /// ```
     ///
-    /// Returns a vector of path secrets.
+    /// Note that this overrides the `path_secrets`.
     pub(crate) fn generate_path_secrets(
+        &mut self,
         ciphersuite: &Ciphersuite,
-        start_secret: &[u8],
-        start_on_leaf: bool,
+        start_secret: Option<&[u8]>,
         n: usize,
-    ) -> Vec<Vec<u8>> {
+    ) {
         let hash_len = ciphersuite.hash_length();
-        let start_secret = if start_on_leaf {
-            hkdf_expand_label(ciphersuite, start_secret, "path", &[], hash_len)
-        } else {
-            start_secret.to_vec()
+        let start_secret = match start_secret {
+            Some(secret) => hkdf_expand_label(ciphersuite, secret, "path", &[], hash_len),
+            None => self.hpke_private_key.as_slice().to_vec(),
         };
         let mut path_secrets = vec![start_secret];
         for i in 0..n - 1 {
@@ -101,7 +132,7 @@ impl OwnLeaf {
                 hkdf_expand_label(ciphersuite, &path_secrets[i], "path", &[], hash_len);
             path_secrets.push(path_secret);
         }
-        path_secrets
+        self.path_secrets = path_secrets
     }
 
     /// Generate the commit secret for the given `path_secret`.
@@ -114,16 +145,23 @@ impl OwnLeaf {
     ///
     /// Returns a path secret that's a `CommitSecret`.
     pub(crate) fn generate_commit_secret(
+        &mut self,
         ciphersuite: &Ciphersuite,
-        path_secret: &[u8],
-    ) -> CommitSecret {
-        CommitSecret(hkdf_expand_label(
+    ) -> Result<(), TreeError> {
+        let path_secret = match self.path_secrets.last() {
+            Some(ps) => ps,
+            None => return Err(TreeError::NoneError),
+        };
+
+        self.commit_secret = CommitSecret(hkdf_expand_label(
             ciphersuite,
             &path_secret,
             "path",
             &[],
             ciphersuite.hash_length(),
-        ))
+        ));
+
+        Ok(())
     }
 
     /// Generate HPKE key pairs for all path secrets in `path_secrets`.
@@ -134,19 +172,36 @@ impl OwnLeaf {
     /// node_priv[n], node_pub[n] = KEM.DeriveKeyPair(node_secret[n])
     /// ```
     ///
-    /// Returns a vector of `HPKEKeyPair`.
+    /// Note that this **extends** existing `path_keys` in this leaf.
+    ///
+    /// Returns a vector of `HPKEPublicKey`.
     pub(crate) fn generate_path_keypairs(
+        &mut self,
         ciphersuite: &Ciphersuite,
-        path_secrets: &[Vec<u8>],
-    ) -> Vec<HPKEKeyPair> {
+        direct_path: &[NodeIndex],
+    ) -> Result<Vec<HPKEPublicKey>, TreeError> {
+        // TODO: Get rid of the potential for error here.
+        assert_eq!(self.path_secrets.len(), direct_path.len());
+        if self.path_secrets.len() != direct_path.len() {
+            return Err(TreeError::InvalidArguments);
+        }
+
         let hash_len = ciphersuite.hash_length();
-        let mut keypairs = vec![];
-        for path_secret in path_secrets {
+        let mut private_keys = vec![];
+        let mut public_keys = vec![];
+
+        // Derive key pairs for all nodes in the direct path.
+        for path_secret in self.path_secrets.iter() {
             let node_secret = hkdf_expand_label(ciphersuite, &path_secret, "node", &[], hash_len);
             let keypair = HPKEKeyPair::derive(&node_secret, ciphersuite);
-            keypairs.push(keypair);
+            public_keys.push(keypair.get_public_key());
+            private_keys.push(keypair.get_private_key());
         }
-        keypairs
+
+        // Store private keys.
+        self.path_keys.add(&private_keys, &direct_path);
+        // Return public keys.
+        Ok(public_keys)
     }
 }
 

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -93,12 +93,6 @@ impl OwnLeaf {
     pub(crate) fn get_path_keys(&self) -> &PathKeys {
         &self.path_keys
     }
-    pub(crate) fn get_path_keys_mut(&mut self) -> &mut PathKeys {
-        &mut self.path_keys
-    }
-    pub(crate) fn set_path_key_pairs(&mut self, new_key_pairs: PathKeys) {
-        self.path_keys = new_key_pairs;
-    }
     pub(crate) fn get_commit_secret(&self) -> CommitSecret {
         self.commit_secret.clone()
     }

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -1,0 +1,111 @@
+//! A data structure holding information about the leaf node in the tree that
+//! belongs to the current client.
+//!
+//! * TODO: functions should operate on `self`.
+
+use super::{index::NodeIndex, path_key_pairs::PathKeypairs};
+use crate::ciphersuite::{Ciphersuite, HPKEKeyPair};
+use crate::codec::{Codec, CodecError};
+use crate::key_packages::KeyPackageBundle;
+use crate::messages::CommitSecret;
+use crate::schedule::hkdf_expand_label;
+
+#[derive(Debug, Clone)]
+pub(crate) struct OwnLeaf {
+    kpb: KeyPackageBundle,
+    node_index: NodeIndex,
+    path_keypairs: PathKeypairs,
+}
+
+impl OwnLeaf {
+    pub(crate) fn new(
+        kpb: KeyPackageBundle,
+        node_index: NodeIndex,
+        path_keypairs: PathKeypairs,
+    ) -> Self {
+        Self {
+            kpb,
+            node_index,
+            path_keypairs,
+        }
+    }
+
+    pub(crate) fn get_kpb(&self) -> &KeyPackageBundle {
+        &self.kpb
+    }
+    pub(crate) fn get_node_index(&self) -> NodeIndex {
+        self.node_index
+    }
+    pub(crate) fn get_path_key_pairs(&self) -> &PathKeypairs {
+        &self.path_keypairs
+    }
+    pub(crate) fn get_path_key_pairs_mut(&mut self) -> &mut PathKeypairs {
+        &mut self.path_keypairs
+    }
+    pub(crate) fn set_path_key_pairs(&mut self, new_key_pairs: PathKeypairs) {
+        self.path_keypairs = new_key_pairs;
+    }
+
+    /// Generate `n` path secrets with the given `start_secret`:
+    /// `path_secret[0] = DeriveSecret(leaf_secret, "path")`
+    pub(crate) fn generate_path_secrets(
+        ciphersuite: &Ciphersuite,
+        start_secret: &[u8],
+        start_on_leaf: bool,
+        n: usize,
+    ) -> (Vec<Vec<u8>>, CommitSecret) {
+        let hash_len = ciphersuite.hash_length();
+        let start_secret = if start_on_leaf {
+            hkdf_expand_label(ciphersuite, start_secret, "path", &[], hash_len)
+        } else {
+            start_secret.to_vec()
+        };
+        let mut path_secrets = vec![start_secret];
+        for i in 0..n - 1 {
+            let path_secret =
+                hkdf_expand_label(ciphersuite, &path_secrets[i], "path", &[], hash_len);
+            path_secrets.push(path_secret);
+        }
+        let commit_secret = CommitSecret(hkdf_expand_label(
+            ciphersuite,
+            &path_secrets.last().unwrap(),
+            "path",
+            &[],
+            hash_len,
+        ));
+        (path_secrets, commit_secret)
+    }
+
+    pub(crate) fn generate_path_keypairs(
+        ciphersuite: &Ciphersuite,
+        path_secrets: &[Vec<u8>],
+    ) -> Vec<HPKEKeyPair> {
+        let hash_len = ciphersuite.hash_length();
+        let mut keypairs = vec![];
+        for path_secret in path_secrets {
+            let node_secret = hkdf_expand_label(ciphersuite, &path_secret, "node", &[], hash_len);
+            let keypair = HPKEKeyPair::derive(&node_secret, ciphersuite);
+            keypairs.push(keypair);
+        }
+        keypairs
+    }
+}
+
+impl Codec for OwnLeaf {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        self.kpb.encode(buffer)?;
+        self.node_index.as_u32().encode(buffer)?;
+        self.path_keypairs.encode(buffer)?;
+        Ok(())
+    }
+    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+    //     let kpb = KeyPackageBundle::decode(cursor)?;
+    //     let node_index = NodeIndex::from(u32::decode(cursor)?);
+    //     let path_keypairs = PathKeypairs::decode(cursor)?;
+    //     Ok(OwnLeaf {
+    //         kpb,
+    //         node_index,
+    //         path_keypairs,
+    //     })
+    // }
+}

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -4,7 +4,7 @@
 
 // TODO: #26 Functions should operate on `self`.
 
-use super::{index::NodeIndex, path_key_pairs::PathKeypairs};
+use super::{index::NodeIndex, path_keys::PathKeys};
 use crate::ciphersuite::{Ciphersuite, HPKEKeyPair, HPKEPrivateKey};
 use crate::codec::{Codec, CodecError};
 use crate::messages::CommitSecret;
@@ -20,19 +20,19 @@ pub(crate) struct OwnLeaf {
     hpke_private_key: HPKEPrivateKey,
 
     // A vector of HPKEKeyPairs in the path from this leaf.
-    path_keypairs: PathKeypairs,
+    path_keys: PathKeys,
 }
 
 impl OwnLeaf {
     pub(crate) fn new(
         hpke_private_key: HPKEPrivateKey,
         node_index: NodeIndex,
-        path_keypairs: PathKeypairs,
+        path_keys: PathKeys,
     ) -> Self {
         Self {
             hpke_private_key,
             node_index,
-            path_keypairs,
+            path_keys,
         }
     }
 
@@ -44,14 +44,14 @@ impl OwnLeaf {
     pub(crate) fn get_node_index(&self) -> NodeIndex {
         self.node_index
     }
-    pub(crate) fn get_path_key_pairs(&self) -> &PathKeypairs {
-        &self.path_keypairs
+    pub(crate) fn get_path_key_pairs(&self) -> &PathKeys {
+        &self.path_keys
     }
-    pub(crate) fn get_path_key_pairs_mut(&mut self) -> &mut PathKeypairs {
-        &mut self.path_keypairs
+    pub(crate) fn get_path_key_pairs_mut(&mut self) -> &mut PathKeys {
+        &mut self.path_keys
     }
-    pub(crate) fn set_path_key_pairs(&mut self, new_key_pairs: PathKeypairs) {
-        self.path_keypairs = new_key_pairs;
+    pub(crate) fn set_path_key_pairs(&mut self, new_key_pairs: PathKeys) {
+        self.path_keys = new_key_pairs;
     }
 
     /// Generate `n` path secrets with the given `start_secret`.
@@ -135,7 +135,7 @@ impl Codec for OwnLeaf {
         // FIXME: do we need this encode? Private keys should not be encoded if not absolutely necessary.
         // self.hpke_private_key.encode(buffer)?;
         self.node_index.as_u32().encode(buffer)?;
-        self.path_keypairs.encode(buffer)?;
+        self.path_keys.encode(buffer)?;
         Ok(())
     }
 }

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -193,7 +193,8 @@ impl OwnLeaf {
         }
 
         // Store private keys.
-        self.path_keys.add(&private_keys, &direct_path);
+        println!("Path indices: {:?}", direct_path);
+        self.path_keys.add(private_keys, &direct_path)?;
         // Return public keys.
         Ok(public_keys)
     }
@@ -204,7 +205,7 @@ impl Codec for OwnLeaf {
         // FIXME: do we need this encode? Private keys should not be encoded if not absolutely necessary.
         // self.hpke_private_key.encode(buffer)?;
         self.node_index.as_u32().encode(buffer)?;
-        self.path_keys.encode(buffer)?;
+        // self.path_keys.encode(buffer)?;
         Ok(())
     }
 }

--- a/src/tree/own_leaf.rs
+++ b/src/tree/own_leaf.rs
@@ -2,8 +2,6 @@
 //! belongs to the current client.
 //!
 
-// TODO: #26 Functions should operate on `self`.
-
 use super::{index::NodeIndex, path_keys::PathKeys, TreeError};
 use crate::ciphersuite::{Ciphersuite, HPKEKeyPair, HPKEPrivateKey, HPKEPublicKey};
 use crate::codec::{Codec, CodecError};

--- a/src/tree/path_key_pairs.rs
+++ b/src/tree/path_key_pairs.rs
@@ -1,0 +1,53 @@
+//! A data structure holding HPKE key pairs for a path in the tree.
+//!
+//! * TODO: probably shouldn't own key pairs.
+//! * TODO: replace `Vec` with a hash map.
+//! * TODO: `add` should return error on invalid inputs
+//!
+use super::index::NodeIndex;
+use crate::ciphersuite::HPKEKeyPair;
+use crate::codec::{encode_vec, Codec, CodecError, VecSize};
+
+#[derive(Default, Debug, Clone)]
+pub struct PathKeypairs {
+    keypairs: Vec<Option<HPKEKeyPair>>,
+}
+
+impl PathKeypairs {
+    pub fn new() -> Self {
+        PathKeypairs { keypairs: vec![] }
+    }
+    pub fn add(&mut self, keypairs: &[HPKEKeyPair], path: &[NodeIndex]) {
+        fn extend_vec(tree_keypairs: &mut PathKeypairs, max_index: NodeIndex) {
+            while tree_keypairs.keypairs.len() <= max_index.as_usize() {
+                tree_keypairs.keypairs.push(None);
+            }
+        }
+        assert_eq!(keypairs.len(), path.len());
+        for i in 0..path.len() {
+            let index = path[i];
+            extend_vec(self, index);
+            self.keypairs[index.as_usize()] = Some(keypairs[i].clone());
+        }
+    }
+    pub fn get(&self, index: NodeIndex) -> Option<&HPKEKeyPair> {
+        if index.as_usize() >= self.keypairs.len() {
+            return None;
+        }
+        match self.keypairs.get(index.as_usize()) {
+            Some(keypair_option) => keypair_option.as_ref(),
+            None => None,
+        }
+    }
+}
+
+impl Codec for PathKeypairs {
+    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+        encode_vec(VecSize::VecU32, buffer, &self.keypairs)?;
+        Ok(())
+    }
+    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+    //     let keypairs = decode_vec(VecSize::VecU32, cursor)?;
+    //     Ok(PathKeypairs { keypairs })
+    // }
+}

--- a/src/tree/path_key_pairs.rs
+++ b/src/tree/path_key_pairs.rs
@@ -4,6 +4,8 @@
 // TODO: probably shouldn't own key pairs.
 // TODO: replace `Vec` with a hash map.
 // TODO: `add` should return error on invalid inputs
+// TODO: This should not hold key pairs but again only private keys. The corresponding
+//       public keys are in the tree nodes.
 //
 use super::index::NodeIndex;
 use crate::ciphersuite::HPKEKeyPair;

--- a/src/tree/path_key_pairs.rs
+++ b/src/tree/path_key_pairs.rs
@@ -1,40 +1,38 @@
 //! A data structure holding HPKE key pairs for a path in the tree.
 //!
-//! * TODO: probably shouldn't own key pairs.
-//! * TODO: replace `Vec` with a hash map.
-//! * TODO: `add` should return error on invalid inputs
-//!
+
+// TODO: probably shouldn't own key pairs.
+// TODO: replace `Vec` with a hash map.
+// TODO: `add` should return error on invalid inputs
+//
 use super::index::NodeIndex;
 use crate::ciphersuite::HPKEKeyPair;
 use crate::codec::{encode_vec, Codec, CodecError, VecSize};
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug)]
 pub struct PathKeypairs {
-    keypairs: Vec<Option<HPKEKeyPair>>,
+    key_pairs: Vec<Option<HPKEKeyPair>>,
 }
 
 impl PathKeypairs {
-    pub fn new() -> Self {
-        PathKeypairs { keypairs: vec![] }
-    }
-    pub fn add(&mut self, keypairs: &[HPKEKeyPair], path: &[NodeIndex]) {
+    pub fn add(&mut self, key_pairs: &[HPKEKeyPair], path: &[NodeIndex]) {
         fn extend_vec(tree_keypairs: &mut PathKeypairs, max_index: NodeIndex) {
-            while tree_keypairs.keypairs.len() <= max_index.as_usize() {
-                tree_keypairs.keypairs.push(None);
+            while tree_keypairs.key_pairs.len() <= max_index.as_usize() {
+                tree_keypairs.key_pairs.push(None);
             }
         }
-        assert_eq!(keypairs.len(), path.len());
+        assert_eq!(key_pairs.len(), path.len());
         for i in 0..path.len() {
             let index = path[i];
             extend_vec(self, index);
-            self.keypairs[index.as_usize()] = Some(keypairs[i].clone());
+            self.key_pairs[index.as_usize()] = Some(key_pairs[i].clone());
         }
     }
     pub fn get(&self, index: NodeIndex) -> Option<&HPKEKeyPair> {
-        if index.as_usize() >= self.keypairs.len() {
+        if index.as_usize() >= self.key_pairs.len() {
             return None;
         }
-        match self.keypairs.get(index.as_usize()) {
+        match self.key_pairs.get(index.as_usize()) {
             Some(keypair_option) => keypair_option.as_ref(),
             None => None,
         }
@@ -43,11 +41,7 @@ impl PathKeypairs {
 
 impl Codec for PathKeypairs {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU32, buffer, &self.keypairs)?;
+        encode_vec(VecSize::VecU32, buffer, &self.key_pairs)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let keypairs = decode_vec(VecSize::VecU32, cursor)?;
-    //     Ok(PathKeypairs { keypairs })
-    // }
 }

--- a/src/tree/path_key_pairs.rs
+++ b/src/tree/path_key_pairs.rs
@@ -2,9 +2,9 @@
 //!
 
 // TODO: probably shouldn't own key pairs.
-// TODO: replace `Vec` with a hash map.
+// TODO: #25 replace `Vec` with a hash map.
 // TODO: `add` should return error on invalid inputs
-// TODO: This should not hold key pairs but again only private keys. The corresponding
+// TODO: #24 This should not hold key pairs but again only private keys. The corresponding
 //       public keys are in the tree nodes.
 //
 use super::index::NodeIndex;

--- a/src/tree/path_keys.rs
+++ b/src/tree/path_keys.rs
@@ -1,49 +1,46 @@
 //! A data structure holding HPKE key pairs for a path in the tree.
 //!
 
-// TODO: probably shouldn't own key pairs.
 // TODO: #25 replace `Vec` with a hash map.
-// TODO: `add` should return error on invalid inputs
 // TODO: #24 This should not hold key pairs but again only private keys. The corresponding
 //       public keys are in the tree nodes.
 //
-use super::index::NodeIndex;
+use super::{index::NodeIndex, TreeError};
 use crate::ciphersuite::HPKEPrivateKey;
-use crate::codec::{encode_vec, Codec, CodecError, VecSize};
+use std::collections::HashMap;
 
+/// A set of keys for a path stored as `HashMap` with entries `(NodeIndex, HPKEPrivateKey)`.
 #[derive(Default, Debug)]
-pub struct PathKeys {
-    keys: Vec<Option<HPKEPrivateKey>>,
+pub(crate) struct PathKeys {
+    keys: HashMap<NodeIndex, HPKEPrivateKey>,
 }
 
 impl PathKeys {
-    pub fn add(&mut self, private_keys: &[HPKEPrivateKey], path: &[NodeIndex]) {
-        fn extend_vec(tree_keypairs: &mut PathKeys, max_index: NodeIndex) {
-            while tree_keypairs.keys.len() <= max_index.as_usize() {
-                tree_keypairs.keys.push(None);
+    /// Add a slice of `HPKEPrivateKey`s with the indices given in `path` to this set of `PathKeys`.
+    ///
+    /// This consumes the private keys.
+    pub fn add(
+        &mut self,
+        private_keys: Vec<HPKEPrivateKey>,
+        path: &[NodeIndex],
+    ) -> Result<(), TreeError> {
+        // TODO: make the API less error prone.
+        assert_eq!(private_keys.len(), path.len());
+        if private_keys.len() != path.len() {
+            return Err(TreeError::InvalidArguments);
+        }
+        let mut private_keys = private_keys;
+
+        for (i, private_key) in private_keys.drain(..).enumerate() {
+            let index = path[i];
+            if self.keys.insert(index, private_key).is_some() {
+                return Err(TreeError::DuplicateIndex);
             }
         }
-        assert_eq!(private_keys.len(), path.len());
-        for i in 0..path.len() {
-            let index = path[i];
-            extend_vec(self, index);
-            self.keys[index.as_usize()] = Some(private_keys[i].clone());
-        }
+
+        Ok(())
     }
     pub fn get(&self, index: NodeIndex) -> Option<&HPKEPrivateKey> {
-        if index.as_usize() >= self.keys.len() {
-            return None;
-        }
-        match self.keys.get(index.as_usize()) {
-            Some(keypair_option) => keypair_option.as_ref(),
-            None => None,
-        }
-    }
-}
-
-impl Codec for PathKeys {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU32, buffer, &self.keys)?;
-        Ok(())
+        self.keys.get(&index)
     }
 }

--- a/src/tree/path_keys.rs
+++ b/src/tree/path_keys.rs
@@ -17,17 +17,17 @@ pub struct PathKeys {
 }
 
 impl PathKeys {
-    pub fn add(&mut self, key_pairs: &[HPKEKeyPair], path: &[NodeIndex]) {
+    pub fn add(&mut self, private_keys: &[HPKEPrivateKey], path: &[NodeIndex]) {
         fn extend_vec(tree_keypairs: &mut PathKeys, max_index: NodeIndex) {
             while tree_keypairs.keys.len() <= max_index.as_usize() {
                 tree_keypairs.keys.push(None);
             }
         }
-        assert_eq!(key_pairs.len(), path.len());
+        assert_eq!(private_keys.len(), path.len());
         for i in 0..path.len() {
             let index = path[i];
             extend_vec(self, index);
-            self.keys[index.as_usize()] = Some(key_pairs[i].get_private_key().clone());
+            self.keys[index.as_usize()] = Some(private_keys[i].clone());
         }
     }
     pub fn get(&self, index: NodeIndex) -> Option<&HPKEPrivateKey> {

--- a/src/tree/path_keys.rs
+++ b/src/tree/path_keys.rs
@@ -8,7 +8,7 @@
 //       public keys are in the tree nodes.
 //
 use super::index::NodeIndex;
-use crate::ciphersuite::{HPKEKeyPair, HPKEPrivateKey};
+use crate::ciphersuite::HPKEPrivateKey;
 use crate::codec::{encode_vec, Codec, CodecError, VecSize};
 
 #[derive(Default, Debug)]

--- a/src/tree/path_keys.rs
+++ b/src/tree/path_keys.rs
@@ -8,42 +8,42 @@
 //       public keys are in the tree nodes.
 //
 use super::index::NodeIndex;
-use crate::ciphersuite::HPKEKeyPair;
+use crate::ciphersuite::{HPKEKeyPair, HPKEPrivateKey};
 use crate::codec::{encode_vec, Codec, CodecError, VecSize};
 
 #[derive(Default, Debug)]
-pub struct PathKeypairs {
-    key_pairs: Vec<Option<HPKEKeyPair>>,
+pub struct PathKeys {
+    keys: Vec<Option<HPKEPrivateKey>>,
 }
 
-impl PathKeypairs {
+impl PathKeys {
     pub fn add(&mut self, key_pairs: &[HPKEKeyPair], path: &[NodeIndex]) {
-        fn extend_vec(tree_keypairs: &mut PathKeypairs, max_index: NodeIndex) {
-            while tree_keypairs.key_pairs.len() <= max_index.as_usize() {
-                tree_keypairs.key_pairs.push(None);
+        fn extend_vec(tree_keypairs: &mut PathKeys, max_index: NodeIndex) {
+            while tree_keypairs.keys.len() <= max_index.as_usize() {
+                tree_keypairs.keys.push(None);
             }
         }
         assert_eq!(key_pairs.len(), path.len());
         for i in 0..path.len() {
             let index = path[i];
             extend_vec(self, index);
-            self.key_pairs[index.as_usize()] = Some(key_pairs[i].clone());
+            self.keys[index.as_usize()] = Some(key_pairs[i].get_private_key().clone());
         }
     }
-    pub fn get(&self, index: NodeIndex) -> Option<&HPKEKeyPair> {
-        if index.as_usize() >= self.key_pairs.len() {
+    pub fn get(&self, index: NodeIndex) -> Option<&HPKEPrivateKey> {
+        if index.as_usize() >= self.keys.len() {
             return None;
         }
-        match self.key_pairs.get(index.as_usize()) {
+        match self.keys.get(index.as_usize()) {
             Some(keypair_option) => keypair_option.as_ref(),
             None => None,
         }
     }
 }
 
-impl Codec for PathKeypairs {
+impl Codec for PathKeys {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU32, buffer, &self.key_pairs)?;
+        encode_vec(VecSize::VecU32, buffer, &self.keys)?;
         Ok(())
     }
 }

--- a/src/tree/path_keys.rs
+++ b/src/tree/path_keys.rs
@@ -1,10 +1,6 @@
 //! A data structure holding HPKE key pairs for a path in the tree.
 //!
 
-// TODO: #25 replace `Vec` with a hash map.
-// TODO: #24 This should not hold key pairs but again only private keys. The corresponding
-//       public keys are in the tree nodes.
-//
 use super::{index::NodeIndex, TreeError};
 use crate::ciphersuite::HPKEPrivateKey;
 use std::collections::HashMap;

--- a/src/tree/test_own_leaf.rs
+++ b/src/tree/test_own_leaf.rs
@@ -1,17 +1,9 @@
 //! Unit test for OwnLeaf
 
 #[cfg(test)]
-use super::{index::NodeIndex, own_leaf::*};
+use super::{index::NodeIndex, own_leaf::*, test_util::*};
 #[cfg(test)]
 use crate::{ciphersuite::*, utils::*};
-
-#[cfg(test)]
-// Generate a random sequence of node indices.
-fn generate_path(len: usize) -> Vec<NodeIndex> {
-    (0..len)
-        .map(|_| NodeIndex::from(random_u8() as u32))
-        .collect()
-}
 
 #[cfg(test)]
 // Common setup for tests.
@@ -20,7 +12,7 @@ fn setup(len: usize) -> (Ciphersuite, HPKEPrivateKey, NodeIndex, Vec<NodeIndex>)
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
     let hpke_private_key = HPKEPrivateKey::from_slice(&randombytes(32));
     let own_index = NodeIndex::from(0u32);
-    let direct_path = generate_path(len);
+    let direct_path = generate_path_u8(len);
 
     (ciphersuite, hpke_private_key, own_index, direct_path)
 }

--- a/src/tree/test_own_leaf.rs
+++ b/src/tree/test_own_leaf.rs
@@ -1,0 +1,58 @@
+//! Unit test for OwnLeaf
+
+#[allow(unused_macros)]
+macro_rules! includes {
+    () => {
+        use super::index::NodeIndex;
+        use super::own_leaf::*;
+        use crate::ciphersuite::*;
+        use crate::utils::*;
+    };
+}
+
+#[test]
+fn create_own_leaf_from_secret() {
+    includes!();
+
+    // Generate a random sequence of node indices.
+    fn generate_path(len: usize) -> Vec<NodeIndex> {
+        (0..len)
+            .map(|_| NodeIndex::from(random_u8() as u32))
+            .collect()
+    }
+
+    const PATH_LENGTH: usize = 33;
+    let ciphersuite =
+        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+    let hpke_private_key = HPKEPrivateKey::from_slice(&randombytes(32));
+    let own_index = NodeIndex::from(0u32);
+    let direct_path = generate_path(PATH_LENGTH);
+
+    let mut own_leaf = OwnLeaf::from_private_key(own_index, hpke_private_key);
+
+    // Compute path secrets form the leaf.
+    own_leaf.generate_path_secrets(&ciphersuite, None, direct_path.len());
+
+    // Compute commit secret.
+    own_leaf.generate_commit_secret(&ciphersuite).unwrap();
+
+    // Generate key pairs and return.
+    let public_keys = own_leaf
+        .generate_path_keypairs(&ciphersuite, &direct_path)
+        .unwrap();
+
+    assert_eq!(public_keys.len(), direct_path.len());
+
+    // Check that we can encrypt to a public key.
+    let path_index = 15;
+    let index = direct_path[path_index];
+    let public_key = &public_keys[path_index];
+    let private_key = own_leaf.get_path_keys().get(index).unwrap();
+    let data = randombytes(55);
+    let info = b"OwnLeaf Test Info";
+    let aad = b"OwnLeaf Test AAD";
+
+    let c = ciphersuite.hpke_seal(public_key, info, aad, &data);
+    let m = ciphersuite.hpke_open(&c, &private_key, info, aad);
+    assert_eq!(m, data);
+}

--- a/src/tree/test_path_keys.rs
+++ b/src/tree/test_path_keys.rs
@@ -1,0 +1,50 @@
+//! Unit test for PathKeys
+
+#[cfg(test)]
+use super::{index::NodeIndex, path_keys::*, test_util::*};
+#[cfg(test)]
+use crate::ciphersuite::*;
+
+#[should_panic]
+#[test]
+fn test_duplicate_index() {
+    fn key() -> HPKEPrivateKey {
+        HPKEPrivateKey::from_slice(&[1, 2, 3, 4, 5, 6])
+    }
+    let path = [
+        NodeIndex::from(1u32),
+        NodeIndex::from(2u32),
+        NodeIndex::from(3u32),
+        NodeIndex::from(1u32),
+    ];
+    let private_keys = vec![key(), key(), key(), key()];
+    let mut path_keys = PathKeys::default();
+    path_keys.add(private_keys, &path[..]).unwrap();
+}
+
+#[test]
+fn test_insert_retrieve() {
+    fn key() -> HPKEPrivateKey {
+        HPKEPrivateKey::from_slice(&[1, 2, 3, 4, 5, 6])
+    }
+    let path = generate_path_u32(2001);
+    let private_keys = (0..1000).map(|_| key()).collect();
+
+    let mut path_keys = PathKeys::default();
+
+    // Some random keys
+    path_keys.add(private_keys, &path[0..1000]).unwrap();
+    // The key we look for
+    path_keys
+        .add(
+            vec![HPKEPrivateKey::from_slice(&[6, 6, 6])],
+            &path[1000..1001],
+        )
+        .unwrap();
+    let private_keys = (0..1000).map(|_| key()).collect();
+    // A couple more random keys
+    path_keys.add(private_keys, &path[1001..2001]).unwrap();
+
+    // Get out the key [6, 6, 6]
+    assert_eq!(&[6, 6, 6], path_keys.get(path[1000]).unwrap().as_slice());
+}

--- a/src/tree/test_util.rs
+++ b/src/tree/test_util.rs
@@ -1,0 +1,36 @@
+//! A bunch of test utilities for tree tests.
+
+#[cfg(test)]
+use super::index::NodeIndex;
+#[cfg(test)]
+use crate::utils::*;
+
+#[cfg(test)]
+/// Generate a random sequence of node indices.
+/// Note that this can be an endless loop if len > u8::MAX
+pub(crate) fn generate_path_u8(len: usize) -> Vec<NodeIndex> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let mut v = NodeIndex::from(random_u8() as u32);
+        while out.contains(&v) {
+            v = NodeIndex::from(random_u8() as u32);
+        }
+        out.push(v)
+    }
+    out
+}
+
+#[cfg(test)]
+/// Generate a random sequence of node indices.
+/// Note that this can be an endless loop if len > u32::MAX
+pub(crate) fn generate_path_u32(len: usize) -> Vec<NodeIndex> {
+    let mut out = Vec::with_capacity(len);
+    for _ in 0..len {
+        let mut v = NodeIndex::from(random_u32());
+        while out.contains(&v) {
+            v = NodeIndex::from(random_u32());
+        }
+        out.push(v)
+    }
+    out
+}

--- a/src/tree/treemath.rs
+++ b/src/tree/treemath.rs
@@ -133,7 +133,7 @@ pub(crate) fn dirpath_long(index: NodeIndex, size: LeafIndex) -> Vec<NodeIndex> 
 
 // Ordered from leaf to root
 // Includes root but not leaf
-pub(crate) fn dirpath_root(index: NodeIndex, size: LeafIndex) -> Vec<NodeIndex> {
+pub(crate) fn direct_path_root(index: NodeIndex, size: LeafIndex) -> Vec<NodeIndex> {
     let mut d = vec![];
     let mut p = parent(index, size);
     let r = root(size);

--- a/src/tree/treemath.rs
+++ b/src/tree/treemath.rs
@@ -14,8 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use std::cmp::Ordering;
 use crate::tree::index::*;
+use std::cmp::Ordering;
 
 pub(crate) fn log2(x: usize) -> usize {
     if x == 0 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,7 @@ pub(crate) fn random_u32() -> u32 {
     OsRng.next_u32()
 }
 
+#[cfg(test)]
 pub(crate) fn random_u8() -> u8 {
     get_random_vec(1)[0]
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,12 +28,13 @@ pub(crate) fn random_u32() -> u32 {
     OsRng.next_u32()
 }
 
+pub(crate) fn random_u8() -> u8 {
+    get_random_vec(1)[0]
+}
+
+#[inline]
 pub(crate) fn zero(length: usize) -> Vec<u8> {
-    let mut result: Vec<u8> = vec![];
-    for _ in 0..length {
-        result.push(0u8);
-    }
-    result
+    vec![0u8; length]
 }
 
 fn _bytes_to_hex(bytes: &[u8]) -> String {

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -47,7 +47,8 @@ fn basic_group_setup() {
     // Alice creates a group
     let group_id = [1, 2, 3, 4];
     // FIXME: We should never have to clone the key package bundle
-    let mut group_alice_1234 = MlsGroup::new(&group_id, ciphersuite, alice_key_package_bundle.clone());
+    let mut group_alice_1234 =
+        MlsGroup::new(&group_id, ciphersuite, alice_key_package_bundle.clone());
 
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
+use evercrypt::prelude::*;
 use rand::rngs::OsRng;
 use rand::RngCore;
-use evercrypt::prelude::*;
 
 pub(crate) fn random_usize() -> usize {
     OsRng.next_u64() as usize


### PR DESCRIPTION
In order to allow for a clean separation of the tree logic, ratchet tree, key schedule, and the group that build on all of this the tree needs to be re-organised.

This is the first of a series of PRs to achieve this.

cc #27 #28
fixes #25 
fixes #24 
fixes #26