### PR TITLE
fix type confusion after hpke update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ rayon = "^1.3"
 rand = "^0.7"
 zeroize = "^1.1"
 byteorder = "^1.3"
-hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", branch = "master"}
-evercrypt = {git = "https://github.com/franziskuskiefer/evercrypt-rust", branch = "master"}
+hpke = { git = "https://github.com/franziskuskiefer/hpke-rs", branch = "master" }
+evercrypt = { version = "0.0.1" }
 
 [features]
 default = ["rust-crypto"]

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -123,7 +123,7 @@ impl Codec for HPKEPrivateKey {
 
 impl Codec for HPKEPublicKey {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU16, buffer, &self.value)?;
+        encode_vec(VecSize::VecU16, buffer, self.as_slice())?;
         Ok(())
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {


### PR DESCRIPTION
HPKE has these types now as well and we have to avoid confusing the types.
They should go away here, but we can only do that after the other open PRs are merged because it requires quite a number of changes.