### PR TITLE
Change API to enforce always MLSCiphertext

### DIFF
--- a/src/group/mls_group/api.rs
+++ b/src/group/mls_group/api.rs
@@ -76,11 +76,11 @@ pub trait Api: Sized {
 
     /// Create application message
     fn create_application_message(
-        &self,
+        &mut self,
         aad: &[u8],
         msg: &[u8],
         signature_key: &SignaturePrivateKey,
-    ) -> MLSPlaintext;
+    ) -> MLSCiphertext;
 
     /// Encrypt an MLS message
     fn encrypt(&mut self, mls_plaintext: MLSPlaintext) -> MLSCiphertext;

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -187,20 +187,21 @@ impl Api for MlsGroup {
 
     // Create application message
     fn create_application_message(
-        &self,
+        &mut self,
         aad: &[u8],
         msg: &[u8],
         signature_key: &SignaturePrivateKey,
-    ) -> MLSPlaintext {
+    ) -> MLSCiphertext {
         let content = MLSPlaintextContentType::Application(msg.to_vec());
-        MLSPlaintext::new(
+        let mls_plaintext = MLSPlaintext::new(
             &self.ciphersuite,
             self.get_sender_index(),
             aad,
             content,
             signature_key,
             &self.get_context(),
-        )
+        );
+        self.encrypt(mls_plaintext)
     }
 
     // Encrypt/Decrypt MLS message

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -27,12 +27,9 @@ fn padding() {
     for _ in 0..100 {
         let message = randombytes(random_usize() % 1000);
         let aad = randombytes(random_usize() % 1000);
-        let mls_plaintext = group_alice.create_application_message(
-            &aad,
-            &message,
-            signature_keypair.get_private_key(),
-        );
-        let encrypted_message = group_alice.encrypt(mls_plaintext).as_slice();
+        let encrypted_message = group_alice
+            .create_application_message(&aad, &message, signature_keypair.get_private_key())
+            .as_slice();
         let length = encrypted_message.len();
         let overflow = length % PADDING_SIZE;
         if overflow != 0 {


### PR DESCRIPTION
This PR changes the API so that it is not possible to create an application message and extract it as an MLSPlaintext.