### PR TITLE
Implement lifetime extension

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -39,7 +39,7 @@ fn criterion_kp_bundle(c: &mut Criterion) {
                     &ciphersuite,
                     signature_keypair.get_private_key(),
                     credential,
-                    None,
+                    Vec::new(),
                 );
             },
         )

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -239,6 +239,16 @@ pub trait Extension: Debug + ExtensionHelper {
             None => Err(ExtensionError::InvalidExtensionType),
         }
     }
+
+    /// Get a reference to the `LifetimeExtension`.
+    /// Returns an `InvalidExtensionType` error if called on an `Extension`
+    /// that's not a `LifetimeExtension`.
+    fn to_lifetime_extension_ref(&self) -> Result<&LifetimeExtension, ExtensionError> {
+        match self.as_any().downcast_ref::<LifetimeExtension>() {
+            Some(e) => Ok(e),
+            None => Err(ExtensionError::InvalidExtensionType),
+        }
+    }
 }
 
 // A slightly hacky work around to make `Extensions` clonable.

--- a/src/extensions/test_extensions.rs
+++ b/src/extensions/test_extensions.rs
@@ -45,3 +45,18 @@ fn key_package_id() {
         &ext_struct.encode_detached().unwrap()[..]
     );
 }
+
+#[test]
+fn lifetime() {
+    const LIFETIME_1_MINUTE: u64 = 60;
+    const LIFETIME_1_HOUR: u64 = 60 * LIFETIME_1_MINUTE;
+
+    // A freshly created extensions must be valid.
+    let ext = LifetimeExtension::new(LIFETIME_1_HOUR);
+    assert!(ext.is_valid());
+
+    // An extension without lifetime is invalid (waiting for 1 second).
+    let ext = LifetimeExtension::new(0);
+    std::thread::sleep(std::time::Duration::from_secs(1));
+    assert!(!ext.is_valid());
+}

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -157,7 +157,7 @@ impl KeyPackageBundle {
         ciphersuite: &Ciphersuite,
         signature_key: &SignaturePrivateKey,
         credential: Credential, // FIXME: must be reference
-        extensions: Option<Vec<Box<dyn Extension>>>,
+        extensions: Vec<Box<dyn Extension>>,
     ) -> Self {
         let keypair = ciphersuite.new_hpke_keypair();
         Self::new_with_keypair(
@@ -177,15 +177,16 @@ impl KeyPackageBundle {
         ciphersuite: &Ciphersuite,
         signature_key: &SignaturePrivateKey,
         credential: Credential,
-        extensions: Option<Vec<Box<dyn Extension>>>,
+        extensions: Vec<Box<dyn Extension>>,
         key_pair: &HPKEKeyPair,
     ) -> Self {
         // TODO: #85 this must be configurable.
         let mut final_extensions: Vec<Box<dyn Extension>> =
             vec![Box::new(CapabilitiesExtension::default())];
-        if let Some(mut extensions) = extensions {
-            final_extensions.append(&mut extensions);
-        }
+
+        // TODO: #31 Make sure we have all necessary extensions.
+
+        final_extensions.extend_from_slice(&extensions);
         let key_package = KeyPackage::new(
             *ciphersuite,
             &key_pair.get_public_key(),

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -44,6 +44,8 @@ impl KeyPackage {
         credential: Credential,
         extensions: Vec<Box<dyn Extension>>,
     ) -> Self {
+        // TODO: #31 Make sure we have all necessary extensions.
+
         let mut key_package = Self {
             // TODO: #85 Take from global config.
             protocol_version: ProtocolVersion::default(),
@@ -184,8 +186,6 @@ impl KeyPackageBundle {
         let mut final_extensions: Vec<Box<dyn Extension>> =
             vec![Box::new(CapabilitiesExtension::default())];
 
-        // TODO: #31 Make sure we have all necessary extensions.
-
         final_extensions.extend_from_slice(&extensions);
         let key_package = KeyPackage::new(
             *ciphersuite,
@@ -205,10 +205,6 @@ impl KeyPackageBundle {
             key_package,
             private_key,
         }
-    }
-
-    pub fn into_tuple(self) -> (HPKEPrivateKey, KeyPackage) {
-        (self.private_key, self.key_package)
     }
 
     /// Get a reference to the `KeyPackage`.

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -11,7 +11,7 @@ fn generate_key_package() {
         &ciphersuite,
         signature_keypair.get_private_key(),
         credential,
-        None,
+        Vec::new(),
     );
     assert!(kpb.get_key_package().verify());
 }
@@ -29,7 +29,7 @@ fn test_codec() {
         &ciphersuite,
         signature_keypair.get_private_key(),
         credential,
-        None,
+        Vec::new(),
     );
     let _enc = kpb.encode_detached().unwrap();
     // let kp = KeyPackage::decode(&mut Cursor::new(&enc)).unwrap();

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -1,24 +1,27 @@
+use crate::extensions::LifetimeExtension;
+#[cfg(test)]
+use crate::key_packages::*;
+
 #[test]
 fn generate_key_package() {
-    use crate::key_packages::*;
     let ciphersuite =
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
     let signature_keypair = ciphersuite.new_signature_keypair();
     let identity =
         Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
     let credential = Credential::Basic(BasicCredential::from(&identity));
+    let lifetime_extension = Box::new(LifetimeExtension::new(60));
     let kpb = KeyPackageBundle::new(
         &ciphersuite,
         signature_keypair.get_private_key(),
         credential,
-        Vec::new(),
+        vec![lifetime_extension],
     );
     assert!(kpb.get_key_package().verify());
 }
 
 #[test]
 fn test_codec() {
-    use crate::key_packages::*;
     let ciphersuite =
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
     let signature_keypair = ciphersuite.new_signature_keypair();

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -404,9 +404,8 @@ impl RatchetTree {
         // Compute the parent hash extension and add it to the KeyPackage
         let key_package_bundle = {
             let parent_hash = self.compute_parent_hash(own_index);
-            let parent_hash_extension = Box::new(ParentHashExtension::new(&parent_hash));
             let mut key_package = key_package_bundle.get_key_package().clone();
-            key_package.add_extension(parent_hash_extension);
+            key_package.update_parent_hash(&parent_hash);
             key_package.sign(&self.ciphersuite, signature_key);
             KeyPackageBundle::from_values(key_package, keypair.get_private_key())
         };

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -60,7 +60,7 @@ fn test_tree_hash() {
             &ciphersuite,
             signature_keypair.get_private_key(),
             credential,
-            None,
+            Vec::new(),
         );
         kbp
     }

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -18,7 +18,7 @@ fn padding() {
         &ciphersuite,
         signature_keypair.get_private_key(),
         credential,
-        None,
+        Vec::new(),
     );
 
     let mut group_alice = MlsGroup::new(&id, ciphersuite, kpb);

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -23,14 +23,14 @@ fn create_commit_optional_path() {
         &ciphersuite,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(alice_credential.clone()), // TODO: this consumes the credential!
-        None,
+        Vec::new(),
     );
 
     let bob_key_package_bundle = KeyPackageBundle::new(
         &ciphersuite,
         &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(bob_credential), // TODO: this consumes the credential!
-        None,
+        Vec::new(),
     );
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
@@ -38,7 +38,7 @@ fn create_commit_optional_path() {
         &ciphersuite,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(alice_credential),
-        None,
+        Vec::new(),
     );
     let alice_update_key_package = alice_update_key_package_bundle.get_key_package();
 
@@ -129,7 +129,7 @@ fn basic_group_setup() {
         &ciphersuite,
         &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(bob_credential), // TODO: this consumes the credential!
-        None,
+        Vec::new(),
     );
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
@@ -137,7 +137,7 @@ fn basic_group_setup() {
         &ciphersuite,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(alice_credential),
-        None,
+        Vec::new(),
     );
 
     // Alice creates a group

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -28,7 +28,7 @@ macro_rules! key_package_generation {
                 &ciphersuite,
                 signature_keypair.get_private_key(),
                 credential,
-                None,
+                Vec::new(),
             );
 
             let extensions = kpb.get_key_package().get_extensions_ref();


### PR DESCRIPTION
This PR works towards #32 by implementing the lifetime extension and making it mandatory in key packages.
The lifetime has basic tests in `test_extensions::lifetime` to check validity. This should be tested more in the context of key packages.

`KeyPackage.verify` now
* verifies that the signature on this key package is valid
* verifies that all mandatory extensions are present
* make sure that the lifetime is valid
There are tests in `generate_key_package` for this.
