### PR TITLE
Don't allow cloning private hpke keys

### DIFF
--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -77,12 +77,12 @@ pub struct HPKEPublicKey {
     value: Vec<u8>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
 pub struct HPKEPrivateKey {
     value: Vec<u8>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq)]
 pub struct HPKEKeyPair {
     private_key: HPKEPrivateKey,
     public_key: HPKEPublicKey,
@@ -402,9 +402,15 @@ impl HPKEKeyPair {
         }
     }
 
+    /// Get the two keys separately.
+    /// Consumes the key pair.
+    pub(crate) fn to_keys(self) -> (HPKEPrivateKey, HPKEPublicKey) {
+        (self.private_key, self.public_key)
+    }
+
     /// Get the private key.
-    pub(crate) fn get_private_key(&self) -> HPKEPrivateKey {
-        self.private_key.clone()
+    pub(crate) fn get_private_key(&self) -> &HPKEPrivateKey {
+        &self.private_key
     }
 
     /// Get the public key.

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -43,6 +43,7 @@ pub enum ApplyCommitError {
     PlaintextSignatureFailure = 206,
     RequiredPathNotFound = 207,
     ConfirmationTagMismatch = 208,
+    MissingOwnKeyPackage = 209,
 }
 
 pub enum DecryptionError {

--- a/src/group/managed_group.rs
+++ b/src/group/managed_group.rs
@@ -38,14 +38,7 @@ impl ManagedGroup {
         ciphersuite: Ciphersuite,
         key_package_bundle: KeyPackageBundle,
     ) -> Self {
-        let group = MlsGroup::new(
-            &group_id.as_slice(),
-            ciphersuite,
-            KeyPackageBundle {
-                private_key: key_package_bundle.get_private_key().clone(),
-                key_package: key_package_bundle.get_key_package().clone(),
-            },
-        );
+        let group = MlsGroup::new(&group_id.as_slice(), ciphersuite, key_package_bundle);
 
         ManagedGroup {
             group,
@@ -61,14 +54,7 @@ impl ManagedGroup {
         ratchet_tree: Option<Vec<Option<Node>>>,
         key_package_bundle: KeyPackageBundle,
     ) -> Result<Self, WelcomeError> {
-        let group = MlsGroup::new_from_welcome(
-            welcome,
-            ratchet_tree,
-            KeyPackageBundle {
-                private_key: key_package_bundle.get_private_key().clone(),
-                key_package: key_package_bundle.get_key_package().clone(),
-            },
-        )?;
+        let group = MlsGroup::new_from_welcome(welcome, ratchet_tree, key_package_bundle)?;
         Ok(ManagedGroup {
             group,
             generation: 0,

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -30,17 +30,11 @@ impl MlsGroup {
         own_key_packages: Vec<KeyPackageBundle>,
     ) -> Result<(), ApplyCommitError> {
         let ciphersuite = self.get_ciphersuite();
+        let mut pending_kpbs = own_key_packages;
 
         // Verify epoch
         if mls_plaintext.epoch != self.group_context.epoch {
             return Err(ApplyCommitError::EpochMismatch);
-        }
-
-        // Create KeyPackageBundles
-        let mut pending_kpbs = vec![];
-        for kpb in own_key_packages {
-            let (pk, kp) = (kpb.private_key, kpb.key_package);
-            pending_kpbs.push(KeyPackageBundle::from_values(kp, pk));
         }
 
         // Extract Commit from MLSPlaintext
@@ -88,11 +82,14 @@ impl MlsGroup {
             }
             if is_own_commit {
                 // Find the right KeyPackageBundle among the pending bundles
-                let own_kpb = pending_kpbs
+                let own_kpb_index = match pending_kpbs
                     .iter()
-                    .find(|&kpb| kpb.get_key_package() == kp)
-                    .unwrap()
-                    .clone();
+                    .position(|kpb| kpb.get_key_package() == kp)
+                {
+                    Some(i) => i,
+                    None => return Err(ApplyCommitError::MissingOwnKeyPackage),
+                };
+                let own_kpb = pending_kpbs.remove(own_kpb_index);
                 provisional_tree
                     .replace_private_tree(own_kpb, &self.group_context.serialize())
                     .unwrap()

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -60,7 +60,7 @@ impl MlsGroup {
         // Create provisional tree and apply proposals
         let mut provisional_tree = self.tree.borrow_mut();
         let (membership_changes, _invited_members, group_removed) =
-            provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, &pending_kpbs);
+            provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, &mut pending_kpbs);
 
         // Check if we were removed from the group
         if group_removed {

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -57,7 +57,7 @@ impl MlsGroup {
 
         // Apply proposals to tree
         let (membership_changes, invited_members, group_removed) =
-            provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, &[]);
+            provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, &mut vec![]);
         if group_removed {
             return Err(CreateCommitError::CannotRemoveSelf);
         }

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -138,7 +138,7 @@ impl Codec for ShortProposalID {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug)]
 pub struct QueuedProposal {
     pub proposal: Proposal,
     pub sender: Sender,
@@ -169,7 +169,7 @@ impl QueuedProposal {
 //     }
 // }
 
-#[derive(Default, Clone)]
+#[derive(Default)]
 pub struct ProposalQueue {
     tuples: HashMap<ShortProposalID, (ProposalID, QueuedProposal)>,
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -425,7 +425,7 @@ impl RatchetTree {
         )?;
 
         // Compute the parent hash extension and update the KeyPackage
-        let csuite =  self.ciphersuite.clone(); // FIXME
+        let csuite = self.ciphersuite.clone(); // FIXME
         let parent_hash = self.compute_parent_hash(own_index);
         let key_package = self.get_own_key_package_ref_mut();
         key_package.update_parent_hash(&parent_hash);

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -371,7 +371,7 @@ impl RatchetTree {
         group_context: &[u8],
     ) -> Result<CommitSecret, TreeError> {
         let _path_option = self.replace_private_tree_(
-            &key_package_bundle,
+            key_package_bundle,
             group_context,
             false, /* without update path */
         )?;
@@ -386,34 +386,31 @@ impl RatchetTree {
     ) -> Result<(CommitSecret, Option<UpdatePath>, Option<PathSecrets>), TreeError> {
         // Generate new keypair
         let own_index = self.get_own_node_index();
-        let keypair = self.ciphersuite.new_hpke_keypair();
+        let (private_key, public_key) = self.ciphersuite.new_hpke_keypair().to_keys();
 
         // Replace the init key in the current KeyPackage
-        let key_package_bundle = {
+        let mut key_package_bundle = {
             // Generate new keypair and replace it in current KeyPackage
             let mut key_package = self.get_own_key_package_ref().clone();
-            key_package.set_hpke_init_key(keypair.get_public_key());
-            KeyPackageBundle::from_values(key_package, keypair.get_private_key())
+            key_package.set_hpke_init_key(public_key);
+            KeyPackageBundle::from_values(key_package, private_key)
         };
+
+        // Compute the parent hash extension and update the KeyPackage
+        let parent_hash = self.compute_parent_hash(own_index);
+        let parent_hash_extension = Box::new(ParentHashExtension::new(&parent_hash));
+        let key_package = key_package_bundle.get_key_package_ref_mut();
+        key_package.add_extension(parent_hash_extension);
+        key_package.sign(&self.ciphersuite, signature_key);
+
+        // Replace the private tree with a new ine based on the new key package
+        // bundle and store the key package in the own node.
         let path_option = self.replace_private_tree_(
-            &key_package_bundle,
+            key_package_bundle,
             group_context,
             true, /* with update path */
         )?;
 
-        // Compute the parent hash extension and add it to the KeyPackage
-        let key_package_bundle = {
-            let parent_hash = self.compute_parent_hash(own_index);
-            let parent_hash_extension = Box::new(ParentHashExtension::new(&parent_hash));
-            let mut key_package = key_package_bundle.get_key_package().clone();
-            key_package.add_extension(parent_hash_extension);
-            key_package.sign(&self.ciphersuite, signature_key);
-            KeyPackageBundle::from_values(key_package, keypair.get_private_key())
-        };
-
-        // Store new KeyPackage in tree
-        self.nodes[own_index.as_usize()] =
-            Node::new_leaf(Some(key_package_bundle.get_key_package().clone()));
         Ok((
             self.private_tree.get_commit_secret(),
             path_option,
@@ -424,39 +421,30 @@ impl RatchetTree {
     /// Replace the private tree with a new one based on the `key_package_bundle`.
     fn replace_private_tree_(
         &mut self,
-        key_package_bundle: &KeyPackageBundle,
+        key_package_bundle: KeyPackageBundle,
         group_context: &[u8],
         with_update_path: bool,
     ) -> Result<Option<UpdatePath>, TreeError> {
-        // TODO: cloning key packages here ...
-        let (private_key, key_package) = (
-            key_package_bundle.get_private_key(),
-            key_package_bundle.get_key_package(),
-        );
+        let (private_key, key_package) = key_package_bundle.into_tuple();
         // Compute the direct path and keypairs along it
         let own_index = self.get_own_node_index();
         let direct_path_root = treemath::direct_path_root(own_index, self.leaf_count());
 
-        // Create new private tree and merge corresponding public keys.
-        let (new_private_tree, new_public_keys) = PrivateTree::new_raw(
-            &self.ciphersuite,
-            own_index,
-            // TODO: this and subsequent clones on kpb should be removed; requires changed output.
-            private_key.clone(),
-            &direct_path_root,
-        )?;
+        // Update private tree and merge corresponding public keys.
+        let new_public_keys =
+            self.private_tree
+                .update(&self.ciphersuite, Some(private_key), &direct_path_root)?;
         self.merge_public_keys(&new_public_keys, &direct_path_root)?;
 
         // Update own leaf node with the new values
         self.nodes[own_index.as_usize()] = Node::new_leaf(Some(key_package.clone()));
-        self.private_tree = new_private_tree;
 
         if !with_update_path {
             return Ok(None);
         }
 
         let update_path_nodes = self.encrypt_to_copath(new_public_keys, group_context)?;
-        let update_path = UpdatePath::new(key_package.clone(), update_path_nodes);
+        let update_path = UpdatePath::new(key_package, update_path_nodes);
         Ok(Some(update_path))
     }
 
@@ -636,12 +624,20 @@ impl RatchetTree {
             self.blank_member(index);
             self.nodes[index.as_usize()] = leaf_node;
             if index == self.get_own_node_index() && !pending_kpbs.is_empty() {
-                let own_kpb = pending_kpbs
+                let own_kpb = match pending_kpbs
                     .iter()
-                    .find(|&kpb| kpb.get_key_package() == &update_proposal.key_package)
-                    .unwrap();
+                    .find(|kpb| kpb.get_key_package() == &update_proposal.key_package)
+                {
+                    Some(i) => i,
+                    None => panic!("Handle this error case"),
+                };
+                // let own_kpb = pending_kpbs.remove(own_kpb_index);
+                // let own_kpb = pending_kpbs
+                //     .iter()
+                //     .find(|&kpb| kpb.get_key_package() == &update_proposal.key_package)
+                //     .unwrap();
                 self.private_tree = PrivateTree::new(
-                    own_kpb.private_key.clone(),
+                    own_kpb.private_key,
                     index,
                     PathKeys::default(),
                     CommitSecret(Vec::new()),

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -115,6 +115,11 @@ impl Node {
             _ => None,
         }
     }
+
+    /// Get a mutable reference to the key package in this node.
+    pub(crate) fn get_key_package_ref_mut(&mut self) -> Option<&mut KeyPackage> {
+        self.key_package.as_mut()
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/tree/path_keys.rs
+++ b/src/tree/path_keys.rs
@@ -27,17 +27,27 @@ impl PathKeys {
             return Err(TreeError::InvalidArguments);
         }
         let mut private_keys = private_keys;
+        println!("private_keys: {:?}", private_keys);
+        println!("path: {:?}", path);
 
         for (i, private_key) in private_keys.drain(..).enumerate() {
             let index = path[i];
             if self.keys.insert(index, private_key).is_some() {
+                assert!(false);
                 return Err(TreeError::DuplicateIndex);
             }
         }
 
         Ok(())
     }
+
+    /// Get an HPKE private key for a given node index.
     pub fn get(&self, index: NodeIndex) -> Option<&HPKEPrivateKey> {
         self.keys.get(&index)
+    }
+
+    /// Clear all path keys.
+    pub(crate) fn clear(&mut self) {
+        self.keys.clear();
     }
 }

--- a/src/tree/path_keys.rs
+++ b/src/tree/path_keys.rs
@@ -27,13 +27,10 @@ impl PathKeys {
             return Err(TreeError::InvalidArguments);
         }
         let mut private_keys = private_keys;
-        println!("private_keys: {:?}", private_keys);
-        println!("path: {:?}", path);
 
         for (i, private_key) in private_keys.drain(..).enumerate() {
             let index = path[i];
             if self.keys.insert(index, private_key).is_some() {
-                assert!(false);
                 return Err(TreeError::DuplicateIndex);
             }
         }

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -64,16 +64,19 @@ impl PrivateTree {
         path: &[NodeIndex],
     ) -> Result<Vec<HPKEPublicKey>, TreeError> {
         // Set new private key if present.
-        self.hpke_private_key = match hpke_private_key {
-            Some(k) => k,
-            None => self.hpke_private_key,
-        };
+        match hpke_private_key {
+            Some(k) => self.hpke_private_key = k,
+            None => (),
+        }
 
         // Compute path secrets.
         self.generate_path_secrets(ciphersuite, None, path.len());
 
         // Compute commit secret.
         self.generate_commit_secret(ciphersuite)?;
+
+        // Clean the path keys for the update.
+        self.path_keys.clear();
 
         // Generate key pairs and return.
         let public_keys = self.generate_path_keypairs(ciphersuite, path)?;
@@ -211,6 +214,7 @@ impl PrivateTree {
         // Store private keys.
         println!("Path indices: {:?}", path);
         self.path_keys.add(private_keys, &path)?;
+
         // Return public keys.
         Ok(public_keys)
     }

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -64,9 +64,8 @@ impl PrivateTree {
         path: &[NodeIndex],
     ) -> Result<Vec<HPKEPublicKey>, TreeError> {
         // Set new private key if present.
-        match hpke_private_key {
-            Some(k) => self.hpke_private_key = k,
-            None => (),
+        if let Some(k) = hpke_private_key {
+            self.hpke_private_key = k
         }
 
         // Compute path secrets.


### PR DESCRIPTION
This is the first step towards getting rid of HPKE key definitions in the ciphersuite and #114 .

This removes the ability to clone HPKE private keys, which requires some changes to how state is moved around.

I didn't add any tests here but the paths are tests with the existing group tests and additional tests should be written for the ciphersuite and relevant paths later.