### PR TITLE
Konrad/x509 field

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -32,7 +32,7 @@ fn criterion_kp_bundle(c: &mut Criterion) {
         b.iter_with_setup(
             || {
                 let identity = Identity::new(ciphersuite, vec![1, 2, 3]);
-                Credential::Basic(BasicCredential::from(&identity))
+                Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)))
             },
             |credential| {
                 KeyPackageBundle::new(

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -80,7 +80,7 @@ impl Codec for Identity {
 }
 
 /// Enum for Credential Types. We only need this for encoding/decoding.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(u16)]
 pub enum CredentialType {
     Reserved = 0,
@@ -161,6 +161,10 @@ impl Credential {
 impl From<MLSCredentialType> for Credential {
     fn from(mls_credential_type: MLSCredentialType) -> Self {
         Credential {
+            credential_type: match mls_credential_type {
+                MLSCredentialType::Basic(_) => CredentialType::Basic,
+                MLSCredentialType::X509(_) => CredentialType::X509,
+            },
             credential: mls_credential_type,
         }
     }

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -77,6 +77,7 @@ impl Codec for Identity {
     // }
 }
 
+/// Enum for Credential Types. We only need this for encoding/decoding.
 #[derive(Copy, Clone)]
 #[repr(u8)]
 pub enum CredentialType {
@@ -105,22 +106,26 @@ impl Codec for CredentialType {
     // }
 }
 
+/// Struct containing an X509 certificate chain, as per Spec.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Certificate {
     cert_data: Vec<u8>,
 }
 
+/// This struct contains the different available certificates.
 #[derive(Debug, PartialEq, Clone)]
 pub enum MLSCredentialType {
     Basic(BasicCredential),
     X509(Certificate),
 }
 
+/// Struct containing MLS credential data, where the data depends on the type.
 pub struct Credential {
     credential: MLSCredentialType,
 }
 
 impl Credential {
+    /// Verify a signature of a given payload against the public key contained in a credential.
     pub fn verify(&self, payload: &[u8], signature: &Signature) -> bool {
         match self.credential {
             MLSCredentialType::Basic(basic_credential) => basic_credential.ciphersuite.verify(
@@ -128,6 +133,7 @@ impl Credential {
                 &basic_credential.public_key,
                 payload,
             ),
+            // TODO: implement verification for X509 certificates
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
@@ -140,6 +146,7 @@ impl Codec for Credential {
                 CredentialType::Basic.encode(buffer)?;
                 basic_credential.encode(buffer)?;
             }
+            // TODO: implement encoding for X509 certificates
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
         Ok(())

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -139,11 +139,11 @@ impl Credential {
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
-    // TODO: implement getter for identity for X509 certificates
     /// Get the identity of a given credential.
     pub fn get_identity(&self) -> &Vec<u8> {
         match &self.credential {
             MLSCredentialType::Basic(basic_credential) => &basic_credential.identity,
+            // TODO: implement getter for identity for X509 certificates
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -106,29 +106,41 @@ impl Codec for CredentialType {
 }
 
 #[derive(Debug, PartialEq, Clone)]
-pub enum Credential {
+pub struct Certificate {
+    cert_data: Vec<u8>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub enum MLSCredentialType {
     Basic(BasicCredential),
+    X509(Certificate),
+}
+
+pub struct Credential {
+    credential: MLSCredentialType,
 }
 
 impl Credential {
     pub fn verify(&self, payload: &[u8], signature: &Signature) -> bool {
-        match self {
-            Credential::Basic(basic_credential) => basic_credential.ciphersuite.verify(
+        match self.credential {
+            MLSCredentialType::Basic(basic_credential) => basic_credential.ciphersuite.verify(
                 signature,
                 &basic_credential.public_key,
                 payload,
             ),
+            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
 }
 
 impl Codec for Credential {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        match self {
-            Credential::Basic(basic_credential) => {
+        match self.credential {
+            MLSCredentialType::Basic(basic_credential) => {
                 CredentialType::Basic.encode(buffer)?;
                 basic_credential.encode(buffer)?;
             }
+            MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
         Ok(())
     }

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -120,7 +120,7 @@ pub struct Certificate {
     cert_data: Vec<u8>,
 }
 
-/// This struct contains the different available certificates.
+/// This enum contains the different available credentials.
 #[derive(Debug, PartialEq, Clone)]
 pub enum MLSCredentialType {
     Basic(BasicCredential),
@@ -130,6 +130,7 @@ pub enum MLSCredentialType {
 /// Struct containing MLS credential data, where the data depends on the type.
 #[derive(Debug, PartialEq, Clone)]
 pub struct Credential {
+    credential_type: CredentialType,
     credential: MLSCredentialType,
 }
 
@@ -143,7 +144,7 @@ impl Credential {
                 &basic_credential.public_key,
                 payload,
             ),
-            // TODO: implement verification for X509 certificates
+            // TODO: implement verification for X509 certificates. See issue #134.
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }
@@ -151,7 +152,7 @@ impl Credential {
     pub fn get_identity(&self) -> &Vec<u8> {
         match &self.credential {
             MLSCredentialType::Basic(basic_credential) => &basic_credential.identity,
-            // TODO: implement getter for identity for X509 certificates
+            // TODO: implement getter for identity for X509 certificates. See issue #134.
             MLSCredentialType::X509(_) => panic!("X509 certificates are not yet implemented."),
         }
     }

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -60,7 +60,7 @@ fn context_presence() {
     let ciphersuite =
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
     let identity = Identity::new(ciphersuite, "Random identity".into());
-    let credential = Credential::Basic(BasicCredential::from(&identity));
+    let credential = Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
     let sender = Sender {
         sender_type: SenderType::Member,
         sender: LeafIndex::from(2u32),

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -8,7 +8,7 @@ fn generate_key_package() {
     let signature_keypair = ciphersuite.new_signature_keypair();
     let identity =
         Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
-    let credential = Credential::Basic(BasicCredential::from(&identity));
+    let credential = Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
     let kpb = KeyPackageBundle::new(
         &ciphersuite,
         signature_keypair.get_private_key(),
@@ -23,7 +23,7 @@ fn generate_key_package() {
     let kpb = KeyPackageBundle::new(
         &ciphersuite,
         signature_keypair.get_private_key(),
-        Credential::Basic(BasicCredential::from(&identity)),
+        Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity))),
         vec![lifetime_extension],
     );
     std::thread::sleep(std::time::Duration::from_secs(1));
@@ -34,7 +34,7 @@ fn generate_key_package() {
     let kpb = KeyPackageBundle::new(
         &ciphersuite,
         signature_keypair.get_private_key(),
-        Credential::Basic(BasicCredential::from(&identity)),
+        Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity))),
         vec![lifetime_extension],
     );
     std::thread::sleep(std::time::Duration::from_secs(1));
@@ -48,7 +48,7 @@ fn test_codec() {
     let signature_keypair = ciphersuite.new_signature_keypair();
     let identity =
         Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
-    let credential = Credential::Basic(BasicCredential::from(&identity));
+    let credential = Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
     let kpb = KeyPackageBundle::new(
         &ciphersuite,
         signature_keypair.get_private_key(),

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -47,8 +47,11 @@ impl fmt::Debug for MembershipChanges {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn list_members(f: &mut fmt::Formatter<'_>, members: &[Credential]) -> fmt::Result {
             for m in members {
-                let Credential::Basic(bc) = m;
-                write!(f, "{} ", String::from_utf8(bc.identity.clone()).unwrap())?;
+                write!(
+                    f,
+                    "{} ",
+                    String::from_utf8(m.get_identity().clone()).unwrap()
+                )?;
             }
             Ok(())
         }

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -78,7 +78,8 @@ fn test_tree_hash() {
     fn create_identity(id: &[u8], ciphersuite: &Ciphersuite) -> KeyPackageBundle {
         let signature_keypair = ciphersuite.new_signature_keypair();
         let identity = Identity::new(*ciphersuite, id.to_vec());
-        let credential = Credential::Basic(BasicCredential::from(&identity));
+        let credential =
+            Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
         let kbp = KeyPackageBundle::new(
             &ciphersuite,
             signature_keypair.get_private_key(),

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -13,7 +13,7 @@ fn padding() {
     let id = vec![1, 2, 3];
     let identity = Identity::new(ciphersuite, vec![1, 2, 3]);
     let signature_keypair = ciphersuite.new_signature_keypair();
-    let credential = Credential::Basic(BasicCredential::from(&identity));
+    let credential = Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
     let kpb = KeyPackageBundle::new(
         &ciphersuite,
         signature_keypair.get_private_key(),

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -22,14 +22,14 @@ fn create_commit_optional_path() {
     let alice_key_package_bundle = KeyPackageBundle::new(
         &ciphersuite,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::Basic(alice_credential.clone()), // TODO: this consumes the credential!
+        Credential::from(MLSCredentialType::Basic(alice_credential.clone())), // TODO: this consumes the credential!
         Vec::new(),
     );
 
     let bob_key_package_bundle = KeyPackageBundle::new(
         &ciphersuite,
         &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::Basic(bob_credential), // TODO: this consumes the credential!
+        Credential::from(MLSCredentialType::Basic(bob_credential)), // TODO: this consumes the credential!
         Vec::new(),
     );
     let bob_key_package = bob_key_package_bundle.get_key_package();
@@ -37,7 +37,7 @@ fn create_commit_optional_path() {
     let alice_update_key_package_bundle = KeyPackageBundle::new(
         &ciphersuite,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::Basic(alice_credential),
+        Credential::from(MLSCredentialType::Basic(alice_credential)),
         Vec::new(),
     );
     let alice_update_key_package = alice_update_key_package_bundle.get_key_package();
@@ -128,7 +128,7 @@ fn basic_group_setup() {
     let bob_key_package_bundle = KeyPackageBundle::new(
         &ciphersuite,
         &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::Basic(bob_credential), // TODO: this consumes the credential!
+        Credential::from(MLSCredentialType::Basic(bob_credential)), // TODO: this consumes the credential!
         Vec::new(),
     );
     let bob_key_package = bob_key_package_bundle.get_key_package();
@@ -136,7 +136,7 @@ fn basic_group_setup() {
     let alice_key_package_bundle = KeyPackageBundle::new(
         &ciphersuite,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::Basic(alice_credential),
+        Credential::from(MLSCredentialType::Basic(alice_credential)),
         Vec::new(),
     );
 

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -23,7 +23,8 @@ macro_rules! key_package_generation {
             let signature_keypair = ciphersuite.new_signature_keypair();
             let identity =
                 Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
-            let credential = Credential::Basic(BasicCredential::from(&identity));
+            let credential =
+                Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
             let kpb = KeyPackageBundle::new(
                 &ciphersuite,
                 signature_keypair.get_private_key(),


### PR DESCRIPTION
Fixes #75 and thus partially #21.

More concretely, it adds a `Credential` struct to match that in the spec as well as an `MLSCredentialType` enum for the individual credential types. The `Credential` impl gets an additional `identity` getter. Also, the `Certificate` credential gets its own struct, although the corresponding implementations panic at the moment, since we don't yet support `X509` certs.