### PR TITLE
use hpke keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ rayon = "^1.3"
 rand = "^0.7"
 zeroize = "^1.1"
 byteorder = "^1.3"
-hpke = { git = "https://github.com/franziskuskiefer/hpke-rs", tag = "v0.0.1", version = "0.0.2-dev" }
+hpke = { git = "https://github.com/franziskuskiefer/hpke-rs", tag = "v0.0.2-dev", version = "0.0.2-dev" }
 evercrypt = { version = "0.0.1" }
 
 [patch.'https://github.com/franziskuskiefer/hpke-rs']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ rayon = "^1.3"
 rand = "^0.7"
 zeroize = "^1.1"
 byteorder = "^1.3"
-hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", tag = "v0.0.1"}
+hpke = { git = "https://github.com/franziskuskiefer/hpke-rs", tag = "v0.0.1", version = "0.0.2-dev" }
 evercrypt = { version = "0.0.1" }
+
+[patch.'https://github.com/franziskuskiefer/hpke-rs']
+hpke = { path = "../hpke-rs" }
 
 [features]
 default = ["rust-crypto"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,6 @@ byteorder = "^1.3"
 hpke = { git = "https://github.com/franziskuskiefer/hpke-rs", tag = "v0.0.2-dev", version = "0.0.2-dev" }
 evercrypt = { version = "0.0.1" }
 
-[patch.'https://github.com/franziskuskiefer/hpke-rs']
-hpke = { path = "../hpke-rs" }
-
 [features]
 default = ["rust-crypto"]
 rust-crypto = ["evercrypt/rust-crypto-aes"]

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -94,33 +94,6 @@ impl Codec for Signature {
     }
 }
 
-// impl Codec for HPKEKeyPair {
-//     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-//         self.private_key.encode(buffer)?;
-//         self.public_key.encode(buffer)?;
-//         Ok(())
-//     }
-//     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-//         let public_key = HPKEPublicKey::decode(cursor)?;
-//         let private_key = HPKEPrivateKey::decode(cursor)?;
-//         Ok(Self {
-//             private_key,
-//             public_key,
-//         })
-//     }
-// }
-
-// impl Codec for HPKEPrivateKey {
-//     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-//         encode_vec(VecSize::VecU16, buffer, &self.value)?;
-//         Ok(())
-//     }
-//     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-//         let inner = decode_vec(VecSize::VecU16, cursor)?;
-//         Ok(Self { value: inner })
-//     }
-// }
-
 impl Codec for HPKEPublicKey {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         encode_vec(VecSize::VecU16, buffer, self.as_slice())?;
@@ -128,7 +101,7 @@ impl Codec for HPKEPublicKey {
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let inner = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(Self { value: inner })
+        Ok(Self::new(inner))
     }
 }
 

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -94,32 +94,32 @@ impl Codec for Signature {
     }
 }
 
-impl Codec for HPKEKeyPair {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.private_key.encode(buffer)?;
-        self.public_key.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let public_key = HPKEPublicKey::decode(cursor)?;
-        let private_key = HPKEPrivateKey::decode(cursor)?;
-        Ok(Self {
-            private_key,
-            public_key,
-        })
-    }
-}
+// impl Codec for HPKEKeyPair {
+//     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+//         self.private_key.encode(buffer)?;
+//         self.public_key.encode(buffer)?;
+//         Ok(())
+//     }
+//     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+//         let public_key = HPKEPublicKey::decode(cursor)?;
+//         let private_key = HPKEPrivateKey::decode(cursor)?;
+//         Ok(Self {
+//             private_key,
+//             public_key,
+//         })
+//     }
+// }
 
-impl Codec for HPKEPrivateKey {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU16, buffer, &self.value)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let inner = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(Self { value: inner })
-    }
-}
+// impl Codec for HPKEPrivateKey {
+//     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
+//         encode_vec(VecSize::VecU16, buffer, &self.value)?;
+//         Ok(())
+//     }
+//     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+//         let inner = decode_vec(VecSize::VecU16, cursor)?;
+//         Ok(Self { value: inner })
+//     }
+// }
 
 impl Codec for HPKEPublicKey {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -255,9 +255,7 @@ impl Ciphersuite {
     ) -> HpkeCiphertext {
         // TODO: put hpke in the ciphersuite.
         let hpke = Hpke::new(Mode::Base, self.hpke_kem, self.hpke_kdf, self.hpke_aead);
-        let (kem_output, ciphertext) = hpke
-            .seal(&pk_r, info, aad, ptxt, None, None, None)
-            .unwrap();
+        let (kem_output, ciphertext) = hpke.seal(&pk_r, info, aad, ptxt, None, None, None).unwrap();
         HpkeCiphertext {
             kem_output,
             ciphertext,
@@ -293,124 +291,13 @@ impl Ciphersuite {
         let hpke = Hpke::new(Mode::Base, self.hpke_kem, self.hpke_kdf, self.hpke_aead);
         HPKEKeyPair::from(hpke.generate_key_pair())
     }
+
+    /// Generate a new HPKE key pair and return it.
+    pub(crate) fn derive_hpke_keypair(&self, ikm: &[u8]) -> HPKEKeyPair {
+        // TODO: put hpke in the ciphersuite.
+        Hpke::new(Mode::Base, self.hpke_kem, self.hpke_kdf, self.hpke_aead).derive_key_pair(ikm)
+    }
 }
-
-// Some internals.
-
-// impl HPKEPublicKey {
-//     pub(crate) fn as_slice(&self) -> &[u8] {
-//         &self.value
-//     }
-//     pub(crate) fn from_slice(bytes: &[u8]) -> Self {
-//         Self {
-//             value: bytes.to_vec(),
-//         }
-//     }
-
-//     fn into(&self) -> RealHPKEPublicKey {
-//         RealHPKEPublicKey::new(self.value.clone())
-//     }
-//     fn from(k: RealHPKEPublicKey) -> Self {
-//         Self {
-//             value: k.as_slice().to_vec(),
-//         }
-//     }
-// }
-
-// impl HPKEPrivateKey {
-//     pub(crate) fn as_slice(&self) -> &[u8] {
-//         &self.value
-//     }
-//     pub(crate) fn from_slice(bytes: &[u8]) -> Self {
-//         Self {
-//             value: bytes.to_vec(),
-//         }
-//     }
-//     pub(crate) fn public_key(&self, hpke_kem: KemMode) -> HPKEPublicKey {
-//         let pk = match hpke_kem {
-//             KemMode::DhKemP256 => p256_base(&self.value).unwrap().to_vec(),
-//             KemMode::DhKemP384 => unimplemented!(),
-//             KemMode::DhKemP521 => unimplemented!(),
-//             KemMode::DhKem25519 => {
-//                 let mut sk = [0u8; 32];
-//                 sk.copy_from_slice(&self.value);
-//                 x25519_base(&sk).to_vec()
-//             }
-//             KemMode::DhKem448 => unimplemented!(),
-//         };
-//         HPKEPublicKey::from_slice(&pk)
-//     }
-
-//     fn into(&self) -> RealHPKEPrivateKey {
-//         RealHPKEPrivateKey::new(self.value.clone())
-//     }
-//     fn from(k: RealHPKEPrivateKey) -> Self {
-//         Self {
-//             value: k.as_slice().to_vec(),
-//         }
-//     }
-// }
-
-// impl HPKEKeyPair {
-//     /// Derive a new key pair for the HPKE KEM with the given input key material.
-//     pub(crate) fn derive(ikm: &[u8], ciphersuite: &Ciphersuite) -> Self {
-//         let key_pair = Hpke::new(
-//             Mode::Base,
-//             ciphersuite.hpke_kem,
-//             ciphersuite.hpke_kdf,
-//             ciphersuite.hpke_aead,
-//         )
-//         .derive_key_pair(ikm);
-//         Self {
-//             private_key: HPKEPrivateKey {
-//                 value: key_pair.get_private_key_ref().as_slice().to_vec(),
-//             },
-//             public_key: HPKEPublicKey {
-//                 value: key_pair.get_public_key_ref().as_slice().to_vec(),
-//             },
-//         }
-//     }
-
-//     // FIXME: remove
-//     /// Build a new HPKE key pair from the given `bytes`.
-//     pub(crate) fn from_slice(bytes: &[u8], ciphersuite: &Ciphersuite) -> Self {
-//         let private_key = HPKEPrivateKey::from_slice(bytes);
-//         let public_key = private_key.public_key(ciphersuite.hpke_kem);
-//         Self {
-//             private_key,
-//             public_key,
-//         }
-//     }
-
-//     /// Get the two keys separately.
-//     /// Consumes the key pair.
-//     pub(crate) fn to_keys(self) -> (HPKEPrivateKey, HPKEPublicKey) {
-//         (self.private_key, self.public_key)
-//     }
-
-//     /// Get the private key.
-//     pub(crate) fn get_private_key(&self) -> &HPKEPrivateKey {
-//         &self.private_key
-//     }
-
-//     /// Get the public key.
-//     pub(crate) fn get_public_key(&self) -> HPKEPublicKey {
-//         self.public_key.clone()
-//     }
-
-//     fn into(&self) -> RealHPKEKeyPair {
-//         RealHPKEKeyPair::new(
-//             self.private_key.value.clone(),
-//             self.public_key.value.clone(),
-//         )
-//     }
-//     fn from(k: RealHPKEKeyPair) -> Self {
-//         Self {
-//             private_key: HPKEPrivateKey::from_slice(k.get_private_key_ref().as_slice()),
-//             public_key: HPKEPublicKey::from_slice(k.get_public_key_ref().as_slice()),
-//         }
-//     }
-// }
 
 impl AeadKey {
     /// Build a new key for an AEAD from `bytes`.

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -21,13 +21,11 @@
 
 use evercrypt::prelude::*;
 use hpke::{
-    aead::Mode as HpkeAeadMode, kdf::Mode as HpkeKdfMode, kem::Mode as KemMode,
-    HPKEKeyPair as RealHPKEKeyPair, HPKEPrivateKey as RealHPKEPrivateKey,
-    HPKEPublicKey as RealHPKEPublicKey, Hpke, Mode,
+    aead::Mode as HpkeAeadMode, kdf::Mode as HpkeKdfMode, kem::Mode as KemMode, Hpke, Mode,
 };
 
-// TODO: re-export for other parts of the library when we can use it
-// pub(crate) use hpke::{HPKEKeyPair, HPKEPrivateKey, HPKEPublicKey};
+// re-export for other parts of the library when we can use it
+pub(crate) use hpke::{HPKEKeyPair, HPKEPrivateKey, HPKEPublicKey};
 
 mod ciphersuites;
 mod codec;
@@ -68,24 +66,6 @@ pub enum HKDFError {
 pub struct HpkeCiphertext {
     kem_output: Vec<u8>,
     ciphertext: Vec<u8>,
-}
-
-// TODO: remove these and use the proper types from HPKE.
-
-#[derive(Debug, PartialEq, Clone)]
-pub struct HPKEPublicKey {
-    value: Vec<u8>,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct HPKEPrivateKey {
-    value: Vec<u8>,
-}
-
-#[derive(Debug, PartialEq)]
-pub struct HPKEKeyPair {
-    private_key: HPKEPrivateKey,
-    public_key: HPKEPublicKey,
 }
 
 // ===
@@ -276,7 +256,7 @@ impl Ciphersuite {
         // TODO: put hpke in the ciphersuite.
         let hpke = Hpke::new(Mode::Base, self.hpke_kem, self.hpke_kdf, self.hpke_aead);
         let (kem_output, ciphertext) = hpke
-            .seal(&pk_r.into(), info, aad, ptxt, None, None, None)
+            .seal(&pk_r, info, aad, ptxt, None, None, None)
             .unwrap();
         HpkeCiphertext {
             kem_output,
@@ -296,7 +276,7 @@ impl Ciphersuite {
         let hpke = Hpke::new(Mode::Base, self.hpke_kem, self.hpke_kdf, self.hpke_aead);
         hpke.open(
             &input.kem_output,
-            &sk_r.into(),
+            &sk_r,
             info,
             aad,
             &input.ciphertext,
@@ -317,120 +297,120 @@ impl Ciphersuite {
 
 // Some internals.
 
-impl HPKEPublicKey {
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        &self.value
-    }
-    pub(crate) fn from_slice(bytes: &[u8]) -> Self {
-        Self {
-            value: bytes.to_vec(),
-        }
-    }
+// impl HPKEPublicKey {
+//     pub(crate) fn as_slice(&self) -> &[u8] {
+//         &self.value
+//     }
+//     pub(crate) fn from_slice(bytes: &[u8]) -> Self {
+//         Self {
+//             value: bytes.to_vec(),
+//         }
+//     }
 
-    fn into(&self) -> RealHPKEPublicKey {
-        RealHPKEPublicKey::new(self.value.clone())
-    }
-    fn from(k: RealHPKEPublicKey) -> Self {
-        Self {
-            value: k.as_slice().to_vec(),
-        }
-    }
-}
+//     fn into(&self) -> RealHPKEPublicKey {
+//         RealHPKEPublicKey::new(self.value.clone())
+//     }
+//     fn from(k: RealHPKEPublicKey) -> Self {
+//         Self {
+//             value: k.as_slice().to_vec(),
+//         }
+//     }
+// }
 
-impl HPKEPrivateKey {
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        &self.value
-    }
-    pub(crate) fn from_slice(bytes: &[u8]) -> Self {
-        Self {
-            value: bytes.to_vec(),
-        }
-    }
-    pub(crate) fn public_key(&self, hpke_kem: KemMode) -> HPKEPublicKey {
-        let pk = match hpke_kem {
-            KemMode::DhKemP256 => p256_base(&self.value).unwrap().to_vec(),
-            KemMode::DhKemP384 => unimplemented!(),
-            KemMode::DhKemP521 => unimplemented!(),
-            KemMode::DhKem25519 => {
-                let mut sk = [0u8; 32];
-                sk.copy_from_slice(&self.value);
-                x25519_base(&sk).to_vec()
-            }
-            KemMode::DhKem448 => unimplemented!(),
-        };
-        HPKEPublicKey::from_slice(&pk)
-    }
+// impl HPKEPrivateKey {
+//     pub(crate) fn as_slice(&self) -> &[u8] {
+//         &self.value
+//     }
+//     pub(crate) fn from_slice(bytes: &[u8]) -> Self {
+//         Self {
+//             value: bytes.to_vec(),
+//         }
+//     }
+//     pub(crate) fn public_key(&self, hpke_kem: KemMode) -> HPKEPublicKey {
+//         let pk = match hpke_kem {
+//             KemMode::DhKemP256 => p256_base(&self.value).unwrap().to_vec(),
+//             KemMode::DhKemP384 => unimplemented!(),
+//             KemMode::DhKemP521 => unimplemented!(),
+//             KemMode::DhKem25519 => {
+//                 let mut sk = [0u8; 32];
+//                 sk.copy_from_slice(&self.value);
+//                 x25519_base(&sk).to_vec()
+//             }
+//             KemMode::DhKem448 => unimplemented!(),
+//         };
+//         HPKEPublicKey::from_slice(&pk)
+//     }
 
-    fn into(&self) -> RealHPKEPrivateKey {
-        RealHPKEPrivateKey::new(self.value.clone())
-    }
-    fn from(k: RealHPKEPrivateKey) -> Self {
-        Self {
-            value: k.as_slice().to_vec(),
-        }
-    }
-}
+//     fn into(&self) -> RealHPKEPrivateKey {
+//         RealHPKEPrivateKey::new(self.value.clone())
+//     }
+//     fn from(k: RealHPKEPrivateKey) -> Self {
+//         Self {
+//             value: k.as_slice().to_vec(),
+//         }
+//     }
+// }
 
-impl HPKEKeyPair {
-    /// Derive a new key pair for the HPKE KEM with the given input key material.
-    pub(crate) fn derive(ikm: &[u8], ciphersuite: &Ciphersuite) -> Self {
-        let key_pair = Hpke::new(
-            Mode::Base,
-            ciphersuite.hpke_kem,
-            ciphersuite.hpke_kdf,
-            ciphersuite.hpke_aead,
-        )
-        .derive_key_pair(ikm);
-        Self {
-            private_key: HPKEPrivateKey {
-                value: key_pair.get_private_key_ref().as_slice().to_vec(),
-            },
-            public_key: HPKEPublicKey {
-                value: key_pair.get_public_key_ref().as_slice().to_vec(),
-            },
-        }
-    }
+// impl HPKEKeyPair {
+//     /// Derive a new key pair for the HPKE KEM with the given input key material.
+//     pub(crate) fn derive(ikm: &[u8], ciphersuite: &Ciphersuite) -> Self {
+//         let key_pair = Hpke::new(
+//             Mode::Base,
+//             ciphersuite.hpke_kem,
+//             ciphersuite.hpke_kdf,
+//             ciphersuite.hpke_aead,
+//         )
+//         .derive_key_pair(ikm);
+//         Self {
+//             private_key: HPKEPrivateKey {
+//                 value: key_pair.get_private_key_ref().as_slice().to_vec(),
+//             },
+//             public_key: HPKEPublicKey {
+//                 value: key_pair.get_public_key_ref().as_slice().to_vec(),
+//             },
+//         }
+//     }
 
-    // FIXME: remove
-    /// Build a new HPKE key pair from the given `bytes`.
-    pub(crate) fn from_slice(bytes: &[u8], ciphersuite: &Ciphersuite) -> Self {
-        let private_key = HPKEPrivateKey::from_slice(bytes);
-        let public_key = private_key.public_key(ciphersuite.hpke_kem);
-        Self {
-            private_key,
-            public_key,
-        }
-    }
+//     // FIXME: remove
+//     /// Build a new HPKE key pair from the given `bytes`.
+//     pub(crate) fn from_slice(bytes: &[u8], ciphersuite: &Ciphersuite) -> Self {
+//         let private_key = HPKEPrivateKey::from_slice(bytes);
+//         let public_key = private_key.public_key(ciphersuite.hpke_kem);
+//         Self {
+//             private_key,
+//             public_key,
+//         }
+//     }
 
-    /// Get the two keys separately.
-    /// Consumes the key pair.
-    pub(crate) fn to_keys(self) -> (HPKEPrivateKey, HPKEPublicKey) {
-        (self.private_key, self.public_key)
-    }
+//     /// Get the two keys separately.
+//     /// Consumes the key pair.
+//     pub(crate) fn to_keys(self) -> (HPKEPrivateKey, HPKEPublicKey) {
+//         (self.private_key, self.public_key)
+//     }
 
-    /// Get the private key.
-    pub(crate) fn get_private_key(&self) -> &HPKEPrivateKey {
-        &self.private_key
-    }
+//     /// Get the private key.
+//     pub(crate) fn get_private_key(&self) -> &HPKEPrivateKey {
+//         &self.private_key
+//     }
 
-    /// Get the public key.
-    pub(crate) fn get_public_key(&self) -> HPKEPublicKey {
-        self.public_key.clone()
-    }
+//     /// Get the public key.
+//     pub(crate) fn get_public_key(&self) -> HPKEPublicKey {
+//         self.public_key.clone()
+//     }
 
-    fn into(&self) -> RealHPKEKeyPair {
-        RealHPKEKeyPair::new(
-            self.private_key.value.clone(),
-            self.public_key.value.clone(),
-        )
-    }
-    fn from(k: RealHPKEKeyPair) -> Self {
-        Self {
-            private_key: HPKEPrivateKey::from_slice(k.get_private_key_ref().as_slice()),
-            public_key: HPKEPublicKey::from_slice(k.get_public_key_ref().as_slice()),
-        }
-    }
-}
+//     fn into(&self) -> RealHPKEKeyPair {
+//         RealHPKEKeyPair::new(
+//             self.private_key.value.clone(),
+//             self.public_key.value.clone(),
+//         )
+//     }
+//     fn from(k: RealHPKEKeyPair) -> Self {
+//         Self {
+//             private_key: HPKEPrivateKey::from_slice(k.get_private_key_ref().as_slice()),
+//             public_key: HPKEPublicKey::from_slice(k.get_public_key_ref().as_slice()),
+//         }
+//     }
+// }
 
 impl AeadKey {
     /// Build a new key for an AEAD from `bytes`.

--- a/src/key_packages/codec.rs
+++ b/src/key_packages/codec.rs
@@ -35,20 +35,3 @@ impl Codec for KeyPackage {
         Ok(kp)
     }
 }
-
-impl Codec for KeyPackageBundle {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.key_package.encode(buffer)?;
-        self.private_key.encode(buffer)?;
-        Ok(())
-    }
-
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let key_package = KeyPackage::decode(cursor)?;
-        let private_key = HPKEPrivateKey::decode(cursor)?;
-        Ok(KeyPackageBundle {
-            key_package,
-            private_key,
-        })
-    }
-}

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -55,7 +55,7 @@ fn test_codec() {
         credential,
         Vec::new(),
     );
-    let _enc = kpb.encode_detached().unwrap();
+    let _enc = kpb.get_key_package().encode_detached().unwrap();
     // let kp = KeyPackage::decode(&mut Cursor::new(&enc)).unwrap();
     // assert_eq!(kpb.key_package, kp);
 }

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -204,7 +204,7 @@ impl PrivateTree {
         // Derive key pairs for all nodes in the direct path.
         for path_secret in self.path_secrets.iter() {
             let node_secret = hkdf_expand_label(ciphersuite, &path_secret, "node", &[], hash_len);
-            let keypair = HPKEKeyPair::derive(&node_secret, ciphersuite);
+            let keypair = ciphersuite.derive_hpke_keypair(&node_secret);
             let (private_key, public_key) = keypair.to_keys();
             public_keys.push(public_key);
             private_keys.push(private_key);

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -3,7 +3,7 @@
 //!
 
 use super::{index::NodeIndex, path_keys::PathKeys, TreeError};
-use crate::ciphersuite::{Ciphersuite, HPKEKeyPair, HPKEPrivateKey, HPKEPublicKey};
+use crate::ciphersuite::{Ciphersuite, HPKEPrivateKey, HPKEPublicKey};
 use crate::codec::{Codec, CodecError};
 use crate::messages::CommitSecret;
 use crate::schedule::hkdf_expand_label;

--- a/src/tree/test_path_keys.rs
+++ b/src/tree/test_path_keys.rs
@@ -9,7 +9,7 @@ use crate::ciphersuite::*;
 #[test]
 fn test_duplicate_index() {
     fn key() -> HPKEPrivateKey {
-        HPKEPrivateKey::from_slice(&[1, 2, 3, 4, 5, 6])
+        HPKEPrivateKey::new(vec![1, 2, 3, 4, 5, 6])
     }
     let path = [
         NodeIndex::from(1u32),
@@ -25,7 +25,7 @@ fn test_duplicate_index() {
 #[test]
 fn test_insert_retrieve() {
     fn key() -> HPKEPrivateKey {
-        HPKEPrivateKey::from_slice(&[1, 2, 3, 4, 5, 6])
+        HPKEPrivateKey::new(vec![1, 2, 3, 4, 5, 6])
     }
     let path = generate_path_u32(2001);
     let private_keys = (0..1000).map(|_| key()).collect();
@@ -37,7 +37,7 @@ fn test_insert_retrieve() {
     // The key we look for
     path_keys
         .add(
-            vec![HPKEPrivateKey::from_slice(&[6, 6, 6])],
+            vec![HPKEPrivateKey::new(vec![6, 6, 6])],
             &path[1000..1001],
         )
         .unwrap();

--- a/src/tree/test_private_tree.rs
+++ b/src/tree/test_private_tree.rs
@@ -10,7 +10,7 @@ use crate::{ciphersuite::*, utils::*};
 fn setup(len: usize) -> (Ciphersuite, HPKEPrivateKey, NodeIndex, Vec<NodeIndex>) {
     let ciphersuite =
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
-    let hpke_private_key = HPKEPrivateKey::from_slice(&randombytes(32));
+    let hpke_private_key = HPKEPrivateKey::new(randombytes(32));
     let own_index = NodeIndex::from(0u32);
     let direct_path = generate_path_u8(len);
 


### PR DESCRIPTION
Remove hpke keys from ciphersuite and use keys provided by the hpke crate.
This works towards cleaning up the ciphersuite #114 .

Note that this conflicts a little with #123, I'll resolve this when #123 is merged.