### PR TITLE
Enable Commit to cover new proposal types

### DIFF
--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -45,6 +45,7 @@ pub enum ApplyCommitError {
     ConfirmationTagMismatch = 208,
     MissingOwnKeyPackage = 209,
     MissingProposal = 210,
+    OwnKeyNotFound = 211,
 }
 
 pub enum DecryptionError {
@@ -60,6 +61,7 @@ impl From<MLSCiphertextError> for DecryptionError {
 #[derive(Debug)]
 pub enum CreateCommitError {
     CannotRemoveSelf = 300,
+    OwnKeyNotFound = 301,
 }
 
 impl From<TreeError> for WelcomeError {

--- a/src/group/errors.rs
+++ b/src/group/errors.rs
@@ -44,6 +44,7 @@ pub enum ApplyCommitError {
     RequiredPathNotFound = 207,
     ConfirmationTagMismatch = 208,
     MissingOwnKeyPackage = 209,
+    MissingProposal = 210,
 }
 
 pub enum DecryptionError {
@@ -74,18 +75,14 @@ impl From<TreeError> for WelcomeError {
 
 // TODO: Should get fixed in #83
 impl From<ConfigError> for ApplyCommitError {
-    fn from(e: ConfigError) -> ApplyCommitError {
-        match e {
-            _ => ApplyCommitError::NoParentHashExtension,
-        }
+    fn from(_e: ConfigError) -> ApplyCommitError {
+        ApplyCommitError::NoParentHashExtension
     }
 }
 
 // TODO: Should get fixed in #83
 impl From<ExtensionError> for ApplyCommitError {
-    fn from(e: ExtensionError) -> ApplyCommitError {
-        match e {
-            _ => ApplyCommitError::NoParentHashExtension,
-        }
+    fn from(_e: ExtensionError) -> ApplyCommitError {
+        ApplyCommitError::NoParentHashExtension
     }
 }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -45,12 +45,6 @@ impl MlsGroup {
             _ => return Err(ApplyCommitError::WrongPlaintextContentType),
         };
 
-        // Organize proposals
-        let proposal_id_list = ProposalIDList {
-            updates: commit.updates.clone(),
-            removes: commit.removes.clone(),
-            adds: commit.adds.clone(),
-        };
         let mut proposal_queue = ProposalQueue::new();
         for mls_plaintext in proposals {
             let queued_proposal = QueuedProposal::new(mls_plaintext, None);
@@ -60,7 +54,7 @@ impl MlsGroup {
         // Create provisional tree and apply proposals
         let mut provisional_tree = self.tree.borrow_mut();
         let (membership_changes, _invited_members, group_removed) =
-            provisional_tree.apply_proposals(&proposal_id_list, proposal_queue, &mut pending_kpbs);
+            provisional_tree.apply_proposals(&commit.proposals, proposal_queue, &mut pending_kpbs);
 
         // Check if we were removed from the group
         if group_removed {

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -46,7 +46,7 @@ impl MlsGroup {
         };
 
         // Convert proposals in a more practical queue
-        let proposal_queue = ProposalQueue::new_from_committed_proposals(proposals, ciphersuite);
+        let proposal_queue = ProposalQueue::new_from_committed_proposals(ciphersuite, proposals);
 
         // Check that we have all proposals from the Commit
         if !proposal_queue.contains(&commit.proposals) {

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -39,7 +39,7 @@ impl MlsGroup {
         // Organize proposals
         let mut proposal_queue = ProposalQueue::new();
         for mls_plaintext in proposals {
-            let queued_proposal = QueuedProposal::new(mls_plaintext, None);
+            let queued_proposal = QueuedProposal::new(mls_plaintext);
             if queued_proposal.sender.as_leaf_index() == self.get_sender_index()
                 && queued_proposal.proposal.is_type(ProposalType::Update)
             {

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -78,9 +78,7 @@ impl MlsGroup {
         };
         // Create commit message
         let commit = Commit {
-            updates: proposal_id_list.updates,
-            removes: proposal_id_list.removes,
-            adds: proposal_id_list.adds,
+            proposals: proposal_id_list,
             path,
         };
         // Create provisional group state

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -41,7 +41,7 @@ impl MlsGroup {
         for mls_plaintext in proposals {
             let queued_proposal = QueuedProposal::new(mls_plaintext, None);
             if queued_proposal.sender.as_leaf_index() == self.get_sender_index()
-                && queued_proposal.proposal.is_update()
+                && queued_proposal.proposal.is_type(ProposalType::Update)
             {
                 contains_own_updates = true;
             } else {
@@ -50,7 +50,7 @@ impl MlsGroup {
         }
 
         // TODO Dedup proposals
-        let proposal_id_list = proposal_queue.get_commit_lists(&ciphersuite);
+        let proposal_id_list = proposal_queue.get_proposal_id_list();
 
         let sender_index = self.get_sender_index();
         let mut provisional_tree = self.tree.borrow_mut();

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -65,17 +65,13 @@ impl fmt::Debug for MembershipChanges {
 
 #[derive(Debug, PartialEq, Clone)]
 pub struct Commit {
-    pub updates: Vec<ProposalID>,
-    pub removes: Vec<ProposalID>,
-    pub adds: Vec<ProposalID>,
+    pub proposals: Vec<ProposalID>,
     pub path: Option<UpdatePath>,
 }
 
 impl Codec for Commit {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU32, buffer, &self.updates)?;
-        encode_vec(VecSize::VecU32, buffer, &self.removes)?;
-        encode_vec(VecSize::VecU32, buffer, &self.adds)?;
+        encode_vec(VecSize::VecU32, buffer, &self.proposals)?;
         self.path.encode(buffer)?;
         Ok(())
     }

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -41,18 +41,11 @@ impl Codec for Commit {
         self.path.encode(buffer)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let updates = decode_vec(VecSize::VecU32, cursor)?;
-    //     let removes = decode_vec(VecSize::VecU32, cursor)?;
-    //     let adds = decode_vec(VecSize::VecU32, cursor)?;
-    //     let path = Option::<UpdatePath>::decode(cursor)?;
-    //     Ok(Commit {
-    //         updates,
-    //         removes,
-    //         adds,
-    //         path,
-    //     })
-    // }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let proposals = decode_vec(VecSize::VecU32, cursor)?;
+        let path = Option::<UpdatePath>::decode(cursor)?;
+        Ok(Commit { proposals, path })
+    }
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -268,18 +261,18 @@ impl Codec for Welcome {
         encode_vec(VecSize::VecU32, buffer, &self.encrypted_group_info)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let version = ProtocolVersion::decode(cursor)?;
-    //     let cipher_suite = Ciphersuite::decode(cursor)?;
-    //     let secrets = decode_vec(VecSize::VecU32, cursor)?;
-    //     let encrypted_group_info = decode_vec(VecSize::VecU32, cursor)?;
-    //     Ok(Welcome {
-    //         version,
-    //         cipher_suite,
-    //         secrets,
-    //         encrypted_group_info,
-    //     })
-    // }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let version = ProtocolVersion::decode(cursor)?;
+        let cipher_suite = Ciphersuite::decode(cursor)?;
+        let secrets = decode_vec(VecSize::VecU32, cursor)?;
+        let encrypted_group_info = decode_vec(VecSize::VecU32, cursor)?;
+        Ok(Welcome {
+            version,
+            cipher_suite,
+            secrets,
+            encrypted_group_info,
+        })
+    }
 }
 
 pub type WelcomeBundle = (Welcome, ExtensionStruct);

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -17,11 +17,9 @@
 use crate::ciphersuite::{signable::*, *};
 use crate::codec::*;
 use crate::config::ProtocolVersion;
-use crate::creds::*;
 use crate::extensions::*;
 use crate::group::*;
 use crate::tree::{index::*, *};
-use std::fmt;
 
 pub(crate) mod proposals;
 use proposals::*;
@@ -29,38 +27,6 @@ use proposals::*;
 #[derive(Debug)]
 pub enum MessageError {
     UnknownOperation,
-}
-
-pub struct MembershipChanges {
-    pub updates: Vec<Credential>,
-    pub removes: Vec<Credential>,
-    pub adds: Vec<Credential>,
-}
-
-impl MembershipChanges {
-    pub fn path_required(&self) -> bool {
-        !self.updates.is_empty() || !self.removes.is_empty() || self.adds.is_empty()
-    }
-}
-
-impl fmt::Debug for MembershipChanges {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fn list_members(f: &mut fmt::Formatter<'_>, members: &[Credential]) -> fmt::Result {
-            for m in members {
-                let Credential::Basic(bc) = m;
-                write!(f, "{} ", String::from_utf8(bc.identity.clone()).unwrap())?;
-            }
-            Ok(())
-        }
-        write!(f, "Membership changes:")?;
-        write!(f, "\n\tUpdates: ")?;
-        list_members(f, &self.updates)?;
-        write!(f, "\n\tRemoves: ")?;
-        list_members(f, &self.removes)?;
-        write!(f, "\n\tAdds: ")?;
-        list_members(f, &self.adds)?;
-        writeln!(f)
-    }
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -157,7 +157,10 @@ impl ProposalQueue {
             queued_proposals: HashMap::new(),
         }
     }
-    pub fn new_from_proposals(proposals: Vec<MLSPlaintext>, ciphersuite: &Ciphersuite) -> Self {
+    pub fn new_from_committed_proposals(
+        proposals: Vec<MLSPlaintext>,
+        ciphersuite: &Ciphersuite,
+    ) -> Self {
         let mut proposal_queue = ProposalQueue::new();
         for mls_plaintext in proposals {
             let queued_proposal = QueuedProposal::new(mls_plaintext);

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -2,7 +2,9 @@ use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::framing::{sender::*, *};
 use crate::key_packages::*;
-use std::collections::HashMap;
+use crate::tree::index::*;
+
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, Copy, Debug)]
 #[repr(u8)]
@@ -112,10 +114,16 @@ pub struct ProposalID {
 }
 
 impl ProposalID {
+    pub fn new_empty() -> Self {
+        Self { value: Vec::new() }
+    }
     pub fn from_proposal(ciphersuite: &Ciphersuite, proposal: &Proposal) -> Self {
         let encoded = proposal.encode_detached().unwrap();
         let value = ciphersuite.hash(&encoded);
         Self { value }
+    }
+    pub fn is_empty(&self) -> bool {
+        self.value.is_empty()
     }
 }
 
@@ -126,48 +134,149 @@ impl Codec for ProposalID {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone)]
 pub struct QueuedProposal {
-    pub proposal: Proposal,
-    pub sender: Sender,
+    proposal: Proposal,
+    proposal_id: ProposalID,
+    sender: Sender,
 }
 
 impl QueuedProposal {
-    pub fn new(mls_plaintext: MLSPlaintext) -> Self {
+    pub(crate) fn new(ciphersuite: &Ciphersuite, mls_plaintext: MLSPlaintext) -> Self {
         debug_assert!(mls_plaintext.content_type == ContentType::Proposal);
         let proposal = match mls_plaintext.content {
             MLSPlaintextContentType::Proposal(p) => p,
             _ => panic!("API misuse. Only proposals can end up in the proposal queue"),
         };
+        let proposal_id = ProposalID::from_proposal(ciphersuite, &proposal);
         Self {
             proposal,
+            proposal_id,
             sender: mls_plaintext.sender,
         }
     }
+    pub(crate) fn get_proposal_ref(&self) -> &Proposal {
+        &self.proposal
+    }
+    pub(crate) fn get_proposal_id_ref(&self) -> &ProposalID {
+        &self.proposal_id
+    }
+    pub(crate) fn get_sender_ref(&self) -> &Sender {
+        &self.sender
+    }
 }
 
+/// Proposal queue that helps filtering and sorting the Proposals from one epoch.
 #[derive(Default)]
 pub struct ProposalQueue {
     queued_proposals: HashMap<ProposalID, QueuedProposal>,
 }
 
 impl ProposalQueue {
+    // Returns a new empty `ProposalQueue`
     pub fn new() -> Self {
         ProposalQueue {
             queued_proposals: HashMap::new(),
         }
     }
+    /// Returns a new `ProposalQueue` from proposals that were committed and don't need filtering
     pub fn new_from_committed_proposals(
-        proposals: Vec<MLSPlaintext>,
         ciphersuite: &Ciphersuite,
+        proposals: Vec<MLSPlaintext>,
     ) -> Self {
         let mut proposal_queue = ProposalQueue::new();
         for mls_plaintext in proposals {
-            let queued_proposal = QueuedProposal::new(mls_plaintext);
-            proposal_queue.add(queued_proposal, &ciphersuite);
+            let queued_proposal = QueuedProposal::new(ciphersuite, mls_plaintext);
+            proposal_queue.add(queued_proposal);
         }
         proposal_queue
     }
+    /// Filters received proposals
+    ///
+    /// 11.2 Commit
+    /// If there are multiple proposals that apply to the same leaf,
+    /// the committer chooses one and includes only that one in the Commit,
+    /// considering the rest invalid. The committer MUST prefer any Remove received,
+    /// or the most recent Update for the leaf if there are no Removes.
+    /// If there are multiple Add proposals for the same client, the committer again
+    /// chooses one to include and considers the rest invalid.
+    ///
+    /// The function performs the following steps:
+    ///
+    /// - Extract Adds and filter for duplicates
+    /// - Build member list with chains: Updates & Removes
+    /// - Check for invalid indexes and drop proposal
+    /// - Check for presence of Removes and delete Updates
+    /// - Only keep the last Update
+    ///
+    /// Return a `ProposalQueue` a bool that indicates whether Updates for the own node were included
+    pub fn filtered_proposals(
+        ciphersuite: &Ciphersuite,
+        proposals: Vec<MLSPlaintext>,
+        own_index: LeafIndex,
+        tree_size: LeafIndex,
+    ) -> (Self, bool) {
+        #[derive(Clone)]
+        struct Member {
+            updates: Vec<QueuedProposal>,
+            removes: Vec<QueuedProposal>,
+        }
+        let mut members: Vec<Member> = vec![
+            Member {
+                updates: vec![],
+                removes: vec![],
+            };
+            tree_size.as_usize()
+        ];
+        let mut adds: HashSet<ProposalID> = HashSet::new();
+        let mut valid_proposals: HashSet<ProposalID> = HashSet::new();
+        let mut proposal_queue = ProposalQueue::new();
+
+        // Parse proposals and build adds and member list
+        for mls_plaintext in proposals {
+            let queued_proposal = QueuedProposal::new(ciphersuite, mls_plaintext);
+            if queued_proposal.proposal.is_type(ProposalType::Add) {
+                adds.insert(queued_proposal.get_proposal_id_ref().clone());
+            }
+            if queued_proposal.proposal.is_type(ProposalType::Update) {
+                let sender_index = queued_proposal.sender.sender.as_usize();
+                if sender_index != own_index.as_usize() {
+                    members[sender_index].updates.push(queued_proposal.clone());
+                }
+            }
+            if queued_proposal.proposal.is_type(ProposalType::Remove) {
+                let removed_index = queued_proposal.proposal.as_remove().unwrap().removed as usize;
+                if removed_index < tree_size.as_usize() {
+                    members[removed_index].updates.push(queued_proposal.clone());
+                } else {
+                    break;
+                }
+            }
+            proposal_queue.add(queued_proposal);
+        }
+        // Check if Updates for own node are included
+        let contains_own_updates = !members[own_index.as_usize()].updates.is_empty();
+        // Check for presence of Removes and delete Updates
+        for member in members.iter_mut() {
+            // Check if there are Removes
+            if !member.removes.is_empty() {
+                // Delete all Updates when a Remove is found
+                member.updates = Vec::new();
+                // Only keep the last Remove
+                valid_proposals
+                    .insert(member.removes.last().unwrap().get_proposal_id_ref().clone());
+            }
+            if !member.updates.is_empty() {
+                // Only keep the last Update
+                valid_proposals
+                    .insert(member.updates.last().unwrap().get_proposal_id_ref().clone());
+            }
+        }
+        // Only retain valid proposals
+        proposal_queue.retain(|k, _| valid_proposals.get(k).is_some() || adds.get(k).is_some());
+        (proposal_queue, contains_own_updates)
+    }
+    /// Returns `true` if all `ProposalID` values from the list are contained in the queue
     pub(crate) fn contains(&self, proposal_id_list: &[ProposalID]) -> bool {
         for proposal_id in proposal_id_list {
             if !self.queued_proposals.contains_key(proposal_id) {
@@ -176,21 +285,24 @@ impl ProposalQueue {
         }
         true
     }
-    pub(crate) fn add(&mut self, queued_proposal: QueuedProposal, ciphersuite: &Ciphersuite) {
-        let proposal_id = ProposalID::from_proposal(ciphersuite, &queued_proposal.proposal);
+    /// Add a new `QueuedProposal` to the queue
+    pub(crate) fn add(&mut self, queued_proposal: QueuedProposal) {
         self.queued_proposals
-            .entry(proposal_id)
+            .entry(queued_proposal.proposal_id.clone())
             .or_insert(queued_proposal);
     }
-    pub(crate) fn _get(&self, proposal_id: &ProposalID) -> Option<&QueuedProposal> {
-        match self.queued_proposals.get(&proposal_id) {
-            Some(queued_proposal) => Some(queued_proposal),
-            None => None,
-        }
+    /// Retains only the elements specified by the predicate
+    pub(crate) fn retain<F>(&mut self, f: F)
+    where
+        F: FnMut(&ProposalID, &mut QueuedProposal) -> bool,
+    {
+        self.queued_proposals.retain(f);
     }
+    /// Gets the list of all `ProposalID`
     pub(crate) fn get_proposal_id_list(&self) -> Vec<ProposalID> {
         self.queued_proposals.keys().into_iter().cloned().collect()
     }
+    /// Return a list of fileterd `QueuedProposal`
     pub(crate) fn get_filtered_proposals(
         &self,
         proposal_id_list: &[ProposalID],

--- a/src/messages/proposals.rs
+++ b/src/messages/proposals.rs
@@ -130,32 +130,21 @@ impl Codec for ProposalID {
 pub struct QueuedProposal {
     pub proposal: Proposal,
     pub sender: Sender,
-    pub own_kpb: Option<KeyPackageBundle>, // TODO check if this can be removed
 }
 
 impl QueuedProposal {
-    pub fn new(mls_plaintext: MLSPlaintext, own_kpb: Option<KeyPackageBundle>) -> Self {
+    pub fn new(mls_plaintext: MLSPlaintext) -> Self {
         debug_assert!(mls_plaintext.content_type == ContentType::Proposal);
         let proposal = match mls_plaintext.content {
             MLSPlaintextContentType::Proposal(p) => p,
-            _ => panic!("API misuses. Only proposals can end up in the proposal queue"),
+            _ => panic!("API misuse. Only proposals can end up in the proposal queue"),
         };
         Self {
             proposal,
             sender: mls_plaintext.sender,
-            own_kpb,
         }
     }
 }
-
-// impl Codec for QueuedProposal {
-//     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-//         self.proposal.encode(buffer)?;
-//         self.sender.encode(buffer)?;
-//         self.own_kpb.encode(buffer)?;
-//         Ok(())
-//     }
-// }
 
 #[derive(Default)]
 pub struct ProposalQueue {
@@ -171,7 +160,7 @@ impl ProposalQueue {
     pub fn new_from_proposals(proposals: Vec<MLSPlaintext>, ciphersuite: &Ciphersuite) -> Self {
         let mut proposal_queue = ProposalQueue::new();
         for mls_plaintext in proposals {
-            let queued_proposal = QueuedProposal::new(mls_plaintext, None);
+            let queued_proposal = QueuedProposal::new(mls_plaintext);
             proposal_queue.add(queued_proposal, &ciphersuite);
         }
         proposal_queue

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -17,7 +17,6 @@
 use crate::ciphersuite::{signable::*, *};
 use crate::codec::*;
 use crate::creds::*;
-use crate::extensions::*;
 use crate::key_packages::*;
 use crate::messages::{proposals::*, *};
 
@@ -425,7 +424,7 @@ impl RatchetTree {
         )?;
 
         // Compute the parent hash extension and update the KeyPackage
-        let csuite = self.ciphersuite.clone(); // FIXME
+        let csuite = self.ciphersuite;
         let parent_hash = self.compute_parent_hash(own_index);
         let key_package = self.get_own_key_package_ref_mut();
         key_package.update_parent_hash(&parent_hash);
@@ -575,8 +574,8 @@ impl RatchetTree {
     }
 
     /// Add nodes for the provided key packages.
-    pub(crate) fn add_nodes(&mut self, new_kp: &[KeyPackage]) -> Vec<(NodeIndex, Credential)> {
-        let num_new_kp = new_kp.len();
+    pub(crate) fn add_nodes(&mut self, new_kps: &[&KeyPackage]) -> Vec<(NodeIndex, Credential)> {
+        let num_new_kp = new_kps.len();
         let mut added_members = Vec::with_capacity(num_new_kp);
 
         if num_new_kp > (2 * self.leaf_count().as_usize()) {
@@ -587,10 +586,9 @@ impl RatchetTree {
         // Add new nodes for key packages into existing free leaves.
         // Note that zip makes it so only the first free_leaves().len() nodes are taken.
         let free_leaves = self.free_leaves();
-        println!("free leaves: {:?}", free_leaves);
         let free_leaves_len = free_leaves.len();
-        for (new_kp, leaf_index) in new_kp.iter().zip(free_leaves) {
-            self.nodes[leaf_index.as_usize()] = Node::new_leaf(Some(new_kp.clone()));
+        for (new_kp, leaf_index) in new_kps.iter().zip(free_leaves) {
+            self.nodes[leaf_index.as_usize()] = Node::new_leaf(Some((*new_kp).clone()));
             let dirpath = treemath::direct_path_root(leaf_index, self.leaf_count())
                 .expect("add_nodes: Error when computing direct path.");
             for d in dirpath.iter() {
@@ -610,10 +608,10 @@ impl RatchetTree {
         // Add the remaining nodes.
         let mut new_nodes = Vec::with_capacity(num_new_kp * 2);
         let mut leaf_index = self.nodes.len() + 1;
-        for add_proposal in new_kp.iter().skip(free_leaves_len) {
+        for add_proposal in new_kps.iter().skip(free_leaves_len) {
             new_nodes.extend(vec![
                 Node::new_blank_parent_node(),
-                Node::new_leaf(Some(add_proposal.clone())),
+                Node::new_leaf(Some((*add_proposal).clone())),
             ]);
             let node_index = NodeIndex::from(leaf_index);
             added_members.push((node_index, add_proposal.get_credential().clone()));
@@ -632,43 +630,55 @@ impl RatchetTree {
     ) -> (MembershipChanges, Vec<(NodeIndex, AddProposal)>, bool) {
         let mut updated_members = vec![];
         let mut removed_members = vec![];
-        let mut invited_members = Vec::with_capacity(proposal_queue.get_adds_ref().len());
+        let mut invited_members = Vec::new();
 
         let mut self_removed = false;
 
-        for u in proposal_queue.get_updates_ref().iter() {
-            let (_proposal_id, queued_proposal) = proposal_queue.get(&u).unwrap();
-            let proposal = &queued_proposal.proposal;
-            let update_proposal = proposal.as_update().unwrap();
-            let sender = queued_proposal.sender;
-            let index = sender.as_node_index();
+        // Check that we have all the referenced proposals from the Commit
+
+        // Process updates first
+        for queued_proposal in proposal_queue
+            .get_filtered_proposals(proposal_id_list, ProposalType::Update)
+            .iter()
+        {
+            let update_proposal = &queued_proposal.proposal.as_update().unwrap();
+            let sender_index = queued_proposal.sender.as_node_index();
+            // Prepare leaf node
             let leaf_node = Node::new_leaf(Some(update_proposal.key_package.clone()));
             updated_members.push(update_proposal.key_package.get_credential().clone());
-            self.blank_member(index);
-            self.nodes[index.as_usize()] = leaf_node;
-            if index == self.get_own_node_index() && !pending_kpbs.is_empty() {
+            // Blank the direct path of that leaf node
+            self.blank_member(sender_index);
+            // Replace the leaf node
+            self.nodes[sender_index.as_usize()] = leaf_node;
+            // Check if it is a self-update
+            if sender_index == self.get_own_node_index() && !pending_kpbs.is_empty() {
                 let own_kpb_index = match pending_kpbs
                     .iter()
                     .position(|kpb| kpb.get_key_package() == &update_proposal.key_package)
                 {
                     Some(i) => i,
+                    // We lost the KeyPackageBundle apparently
                     None => panic!("Handle this error case"),
                 };
+                // Remove own KeyPackageBundle from the list of available ones
                 let own_kpb = pending_kpbs.remove(own_kpb_index);
+                // Update the private tree with new values
                 self.private_tree = PrivateTree::new(
                     own_kpb.private_key,
-                    index,
+                    sender_index,
                     PathKeys::default(),
                     CommitSecret(Vec::new()),
                     Vec::new(),
                 );
             }
         }
-        for r in proposal_queue.get_removes_ref().iter() {
-            let (_proposal_id, queued_proposal) = proposal_queue.get(&r).unwrap();
-            let proposal = &queued_proposal.proposal;
-            let remove_proposal = proposal.as_remove().unwrap();
+        for queued_proposal in proposal_queue
+            .get_filtered_proposals(proposal_id_list, ProposalType::Remove)
+            .iter()
+        {
+            let remove_proposal = &queued_proposal.proposal.as_remove().unwrap();
             let removed = NodeIndex::from(remove_proposal.removed);
+            // Check if we got removed from the group
             if removed == self.get_own_node_index() {
                 self_removed = true;
             }
@@ -684,30 +694,21 @@ impl RatchetTree {
         }
 
         // Process adds
-        let added_members = if !proposal_queue.get_adds_ref().is_empty() {
-            let add_proposals: Vec<AddProposal> = proposal_queue
-                .get_adds_ref()
-                .iter()
-                .map(|a| {
-                    let (_proposal_id, queued_proposal) = proposal_queue.get(&a).unwrap();
-                    let proposal = &queued_proposal.proposal;
-                    proposal.as_add().unwrap()
-                })
-                .collect();
-            // TODO make sure intermediary nodes are updated with unmerged_leaves
-            let key_packages: Vec<KeyPackage> = add_proposals
-                .iter()
-                .map(|a| a.key_package.clone())
-                .collect();
-            let added = self.add_nodes(&key_packages);
+        let add_proposals: Vec<AddProposal> = proposal_queue
+            .get_filtered_proposals(proposal_id_list, ProposalType::Add)
+            .iter()
+            .map(|queued_proposal| {
+                let proposal = &queued_proposal.proposal;
+                proposal.as_add().unwrap()
+            })
+            .collect();
+        // TODO make sure intermediary nodes are updated with unmerged_leaves
+        let key_packages: Vec<&KeyPackage> = add_proposals.iter().map(|a| &a.key_package).collect();
+        let added_members = self.add_nodes(&key_packages);
 
-            for (i, added) in added.iter().enumerate() {
-                invited_members.push((added.0, add_proposals.get(i).unwrap().clone()));
-            }
-            added
-        } else {
-            Vec::new()
-        };
+        for (i, added) in added_members.iter().enumerate() {
+            invited_members.push((added.0, add_proposals.get(i).unwrap().clone()));
+        }
 
         // Return membership changes
         (

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -646,8 +646,8 @@ impl RatchetTree {
             .iter()
         {
             has_updates = true;
-            let update_proposal = &queued_proposal.proposal.as_update().unwrap();
-            let sender_index = queued_proposal.sender.as_node_index();
+            let update_proposal = &queued_proposal.get_proposal_ref().as_update().unwrap();
+            let sender_index = queued_proposal.get_sender_ref().as_node_index();
             // Prepare leaf node
             let leaf_node = Node::new_leaf(Some(update_proposal.key_package.clone()));
             // Blank the direct path of that leaf node
@@ -681,7 +681,7 @@ impl RatchetTree {
             .iter()
         {
             has_removes = true;
-            let remove_proposal = &queued_proposal.proposal.as_remove().unwrap();
+            let remove_proposal = &queued_proposal.get_proposal_ref().as_remove().unwrap();
             let removed = NodeIndex::from(remove_proposal.removed);
             // Check if we got removed from the group
             if removed == self.get_own_node_index() {
@@ -696,7 +696,7 @@ impl RatchetTree {
             .get_filtered_proposals(proposal_id_list, ProposalType::Add)
             .iter()
             .map(|queued_proposal| {
-                let proposal = &queued_proposal.proposal;
+                let proposal = &queued_proposal.get_proposal_ref();
                 proposal.as_add().unwrap()
             })
             .collect();

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -626,17 +626,17 @@ impl RatchetTree {
 
     pub fn apply_proposals(
         &mut self,
-        proposal_id_list: &ProposalIDList,
+        proposal_id_list: &[ProposalID],
         proposal_queue: ProposalQueue,
         pending_kpbs: &mut Vec<KeyPackageBundle>,
     ) -> (MembershipChanges, Vec<(NodeIndex, AddProposal)>, bool) {
         let mut updated_members = vec![];
         let mut removed_members = vec![];
-        let mut invited_members = Vec::with_capacity(proposal_id_list.adds.len());
+        let mut invited_members = Vec::with_capacity(proposal_queue.get_adds_ref().len());
 
         let mut self_removed = false;
 
-        for u in proposal_id_list.updates.iter() {
+        for u in proposal_queue.get_updates_ref().iter() {
             let (_proposal_id, queued_proposal) = proposal_queue.get(&u).unwrap();
             let proposal = &queued_proposal.proposal;
             let update_proposal = proposal.as_update().unwrap();
@@ -664,7 +664,7 @@ impl RatchetTree {
                 );
             }
         }
-        for r in proposal_id_list.removes.iter() {
+        for r in proposal_queue.get_removes_ref().iter() {
             let (_proposal_id, queued_proposal) = proposal_queue.get(&r).unwrap();
             let proposal = &queued_proposal.proposal;
             let remove_proposal = proposal.as_remove().unwrap();
@@ -684,9 +684,9 @@ impl RatchetTree {
         }
 
         // Process adds
-        let added_members = if !proposal_id_list.adds.is_empty() {
-            let add_proposals: Vec<AddProposal> = proposal_id_list
-                .adds
+        let added_members = if !proposal_queue.get_adds_ref().is_empty() {
+            let add_proposals: Vec<AddProposal> = proposal_queue
+                .get_adds_ref()
                 .iter()
                 .map(|a| {
                     let (_proposal_id, queued_proposal) = proposal_queue.get(&a).unwrap();

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -102,7 +102,7 @@ fn test_tree_hash() {
     for _ in 0..5 {
         nodes.push(create_identity(b"Tree creator", &ciphersuite));
     }
-    let key_packages: Vec<KeyPackage> = nodes.iter().map(|kbp| kbp.key_package.clone()).collect();
+    let key_packages: Vec<&KeyPackage> = nodes.iter().map(|kbp| &kbp.key_package).collect();
     let _ = tree.add_nodes(&key_packages);
     let tree_hash = tree.compute_tree_hash();
     println!("Tree hash: {:?}", tree_hash);


### PR DESCRIPTION
This PR addresses the MLS protocol spec changes of how proposals are serialized inside Commits.
Additionally, there is some refactoring of how Commits are generated and processed:

  - Apply Commit: check we have all proposals
  - Create Commit: Filter proposals from current epoch
  - Internal: get rid of membership changes
  - Internal: Refactor how path_required is calculated 
  - Internal: get rid keypackages in queued nodes
  - Internal/API: error handling
  - Documentation: more code is now documented
  
This PR does not have tests yet due to it's size. Tests will be included in a follow-up PR.
This PR also does not cover creating and processing new Proposal types like PSK & ReInit. This will be addressed in #76.