### PR TITLE
Global config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,10 @@ edition = "2018"
 uuid = { version = "0.8", features = ["v4"] }
 rayon = "^1.3"
 rand = "^0.7"
-zeroize = "^1.1"
 byteorder = "^1.3"
+lazy_static = "1.4"
+serde = { version = "^1.0", features = ["derive"] }
+serde_json = "^1.0"
 hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", tag = "v0.0.1"}
 evercrypt = { version = "0.0.1" }
 

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -25,6 +25,7 @@ use hpke::{
     HPKEKeyPair as RealHPKEKeyPair, HPKEPrivateKey as RealHPKEPrivateKey,
     HPKEPublicKey as RealHPKEPublicKey, Hpke, Mode,
 };
+use serde::{Deserialize, Serialize};
 
 // TODO: re-export for other parts of the library when we can use it
 // pub(crate) use hpke::{HPKEKeyPair, HPKEPrivateKey, HPKEPublicKey};
@@ -41,7 +42,7 @@ pub const AES_256_KEY_BYTES: usize = 32;
 pub const TAG_BYTES: usize = 16;
 
 #[allow(non_camel_case_types)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CiphersuiteName {
     MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519 = 0x0001,
     MLS10_128_DHKEMP256_AES128GCM_SHA256_P256 = 0x0002,

--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ lazy_static! {
                     CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
                     CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
                     CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256],
-                    extensions: vec![ExtensionType::Lifetime, ExtensionType::Capabilities, ExtensionType::KeyID],
+                    extensions: vec![ExtensionType::Capabilities, ExtensionType::Lifetime, ExtensionType::KeyID],
             }
 
         }
@@ -98,32 +98,30 @@ impl ProtocolVersion {
 }
 
 impl CiphersuiteName {
+    /// Returns `true` if the ciphersuite is supported in the current configuration.
     pub(crate) fn is_supported(&self) -> bool {
-        matches!(
-            self,
-            CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519
-                | CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519
-        )
+        for suite in CONFIG.ciphersuites.iter() {
+            if self == suite {
+                return true
+            }
+        }
+        return false;
     }
 }
 
 impl Config {
     /// Get a list of the supported extension types.
-    pub fn supported_extensions() -> Vec<ExtensionType> {
-        vec![ExtensionType::Lifetime]
+    pub fn supported_extensions() -> &'static [ExtensionType] {
+        &CONFIG.extensions
     }
 
     /// Get a list of the supported cipher suite names.
-    pub fn supported_ciphersuites() -> Vec<CiphersuiteName> {
-        vec![
-            CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
-            CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
-            CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256,
-        ]
+    pub fn supported_ciphersuites() -> &'static [CiphersuiteName] {
+        &CONFIG.ciphersuites
     }
 
     /// Get a list of the supported protocol versions.
-    pub fn supported_versions() -> Vec<ProtocolVersion> {
-        vec![ProtocolVersion::Mls10]
+    pub fn supported_versions() -> &'static [ProtocolVersion] {
+        &CONFIG.protocol_versions
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,17 +1,56 @@
 //! This config contains all structs, enums and functions to configure MLS.
 //!
 
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+use std::{env, fs::File, io::BufReader};
+
 use crate::ciphersuite::CiphersuiteName;
 use crate::codec::{Codec, CodecError};
 use crate::errors::ConfigError;
 use crate::extensions::ExtensionType;
+
+lazy_static! {
+    static ref CONFIG: Config = {
+        if let Ok(path) = env::var("OPENMLS_CONFIG") {
+            let file = match File::open(path) {
+                Ok(f) => f,
+                Err(e) => panic!("Couldn't open file {}.\nPlease set \
+                                  OPENMLS_CONFIG to a valid path or unset it to \
+                                  use the default configuration.", e),
+            };
+            let reader = BufReader::new(file);
+            let config: Config = match serde_json::from_reader(reader) {
+                Ok(r) => r,
+                Err(e) => panic!("Error reading configuration file.\n{:?}", e),
+            };
+            config
+        } else {
+            // Without a config file everything is enabled.
+            Config {
+                protocol_versions: vec![ProtocolVersion::Mls10],
+                ciphersuites: vec![
+                    CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519,
+                    CiphersuiteName::MLS10_128_DHKEMX25519_CHACHA20POLY1305_SHA256_Ed25519,
+                    CiphersuiteName::MLS10_128_DHKEMP256_AES128GCM_SHA256_P256],
+                    extensions: vec![ExtensionType::Lifetime, ExtensionType::Capabilities, ExtensionType::KeyID],
+            }
+
+        }
+    };
+}
 
 /// # MLS Configuration
 ///
 /// This is the global configuration for MLS.
 ///
 /// TODO: #85 This doesn't do much yet.
-pub struct Config {}
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Config {
+    protocol_versions: Vec<ProtocolVersion>,
+    ciphersuites: Vec<CiphersuiteName>,
+    extensions: Vec<ExtensionType>,
+}
 
 /// # Protocol Version
 ///
@@ -25,7 +64,7 @@ pub struct Config {}
 /// } ProtocolVersion;
 /// ```
 ///
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(u8)]
 pub enum ProtocolVersion {
     Reserved = 0,

--- a/src/config.rs
+++ b/src/config.rs
@@ -105,7 +105,7 @@ impl CiphersuiteName {
                 return true;
             }
         }
-        return false;
+        false
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,7 +102,7 @@ impl CiphersuiteName {
     pub(crate) fn is_supported(&self) -> bool {
         for suite in CONFIG.ciphersuites.iter() {
             if self == suite {
-                return true
+                return true;
             }
         }
         return false;

--- a/src/extensions/capabilities_extension.rs
+++ b/src/extensions/capabilities_extension.rs
@@ -31,9 +31,9 @@ pub struct CapabilitiesExtension {
 impl Default for CapabilitiesExtension {
     fn default() -> Self {
         CapabilitiesExtension {
-            versions: Config::supported_versions(),
-            ciphersuites: Config::supported_ciphersuites(),
-            extensions: Config::supported_extensions(),
+            versions: Config::supported_versions().to_vec(),
+            ciphersuites: Config::supported_ciphersuites().to_vec(),
+            extensions: Config::supported_extensions().to_vec(),
         }
     }
 }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -16,6 +16,7 @@
 
 use crate::codec::{decode_vec, encode_vec, Codec, CodecError, Cursor, VecSize};
 use crate::errors::ConfigError;
+use serde::{Deserialize, Serialize};
 use std::{any::Any, fmt::Debug};
 
 mod capabilities_extension;
@@ -56,7 +57,7 @@ impl From<ExtensionError> for CodecError {
 ///
 /// [IANA registrations](https://messaginglayersecurity.rocks/mls-protocol/draft-ietf-mls-protocol.html#name-mls-extension-types)
 ///
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[repr(u16)]
 pub enum ExtensionType {
     Reserved = 0,

--- a/src/extensions/test_extensions.rs
+++ b/src/extensions/test_extensions.rs
@@ -9,7 +9,7 @@ use crate::codec::{Codec, Cursor};
 #[test]
 fn capabilities() {
     // A capabilities extension with the default values for maelstrom.
-    let extension_bytes = [0, 1, 0, 12, 1, 1, 6, 0, 1, 0, 3, 0, 2, 2, 0, 2];
+    let extension_bytes = [0, 1, 0, 16, 1, 1, 6, 0, 1, 0, 3, 0, 2, 6, 0, 1, 0, 2, 0, 3];
 
     let ext = CapabilitiesExtension::default();
     let ext_struct = ext.to_extension_struct();
@@ -29,7 +29,7 @@ fn capabilities() {
 #[test]
 fn key_package_id() {
     // A key package extension with the default values for maelstrom.
-    let extension_bytes = [0, 1, 0, 12, 1, 1, 6, 0, 1, 0, 3, 0, 2, 2, 0, 2];
+    let extension_bytes = [0, 1, 0, 16, 1, 1, 6, 0, 1, 0, 3, 0, 2, 6, 0, 1, 0, 2, 0, 3];
 
     let ext = CapabilitiesExtension::default();
     let ext_struct = ext.to_extension_struct();

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,0 +1,13 @@
+{
+    "protocol_versions": [
+        1
+    ],
+    "ciphersuites": [
+        1
+    ],
+    "extensions": [
+        1,
+        2,
+        3
+    ]
+}

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -38,7 +38,14 @@ fn protocol_version() {
 fn default_extensions() {
     // Make sure the supported extensions are what we expect them to be.
     let supported_extensions = Config::supported_extensions();
-    assert_eq!(vec![ExtensionType::Lifetime], supported_extensions);
+    assert_eq!(
+        vec![
+            ExtensionType::Capabilities,
+            ExtensionType::Lifetime,
+            ExtensionType::KeyID
+        ],
+        supported_extensions
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR adds a global configuration to maelstrom (#85).
Pointing the `OPENMLS_CONFIG` environment variable to a JSON serialized config file (see `tests/config.json` for an example) sets the config used when running the library.

There are currently no tests for this, this needs a little additional infrastructure and isn't super high priority. The default case is tested.