### PR TITLE
welcome messages & ciphersuite cleanup

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -26,9 +26,8 @@ use maelstrom::key_packages::*;
 
 fn criterion_kp_bundle(c: &mut Criterion) {
     c.bench_function("KeyPackage create bundle", |b| {
-        let ciphersuite =
-            Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
-        let signature_keypair = ciphersuite.new_signature_keypair();
+        let ciphersuite = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+        let signature_keypair = Ciphersuite::new(ciphersuite).new_signature_keypair();
         b.iter_with_setup(
             || {
                 let identity = Identity::new(ciphersuite, vec![1, 2, 3]);
@@ -36,7 +35,7 @@ fn criterion_kp_bundle(c: &mut Criterion) {
             },
             |credential| {
                 KeyPackageBundle::new(
-                    &ciphersuite,
+                    ciphersuite,
                     signature_keypair.get_private_key(),
                     credential,
                     Vec::new(),

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -157,6 +157,11 @@ impl Ciphersuite {
         }
     }
 
+    /// Get the name of this ciphersuite.
+    pub fn get_name(&self) -> CiphersuiteName {
+        self.name
+    }
+
     /// Sign a `msg` with the given `sk`.
     pub(crate) fn sign(
         &self,

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{env, fs::File, io::BufReader};
 
 use crate::ciphersuite::CiphersuiteName;
-use crate::codec::{Codec, CodecError};
+use crate::codec::{Codec, CodecError, Cursor};
 use crate::errors::ConfigError;
 use crate::extensions::ExtensionType;
 
@@ -82,6 +82,10 @@ impl Codec for ProtocolVersion {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         (*self as u8).encode(buffer)?;
         Ok(())
+    }
+
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        Ok(Self::from(u8::decode(cursor)?)?)
     }
 }
 

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -27,7 +27,8 @@ pub struct Identity {
 }
 
 impl Identity {
-    pub fn new(ciphersuite: Ciphersuite, id: Vec<u8>) -> Self {
+    pub fn new(ciphersuite_name: CiphersuiteName, id: Vec<u8>) -> Self {
+        let ciphersuite = Ciphersuite::new(ciphersuite_name);
         let keypair = ciphersuite.new_signature_keypair();
         Self {
             id,

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -57,9 +57,9 @@ fn codec() {
 fn context_presence() {
     use crate::ciphersuite::*;
 
-    let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
-    let identity = Identity::new(ciphersuite, "Random identity".into());
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let ciphersuite = Ciphersuite::new(ciphersuite_name);
+    let identity = Identity::new(ciphersuite_name, "Random identity".into());
     let credential = Credential::Basic(BasicCredential::from(&identity));
     let sender = Sender {
         sender_type: SenderType::Member,

--- a/src/group/managed_group.rs
+++ b/src/group/managed_group.rs
@@ -35,10 +35,10 @@ pub struct ManagedGroup {
 impl ManagedGroup {
     pub fn new(
         group_id: GroupId,
-        ciphersuite: Ciphersuite,
+        ciphersuite_name: CiphersuiteName,
         key_package_bundle: KeyPackageBundle,
     ) -> Self {
-        let group = MlsGroup::new(&group_id.as_slice(), ciphersuite, key_package_bundle);
+        let group = MlsGroup::new(&group_id.as_slice(), ciphersuite_name, key_package_bundle);
 
         ManagedGroup {
             group,

--- a/src/group/mls_group/api.rs
+++ b/src/group/mls_group/api.rs
@@ -24,9 +24,9 @@ pub trait Api: Sized {
     /// Create a new group.
     fn new(
         group_id: &[u8],
-        ciphersuite: Ciphersuite,
+        ciphersuite_name: CiphersuiteName,
         key_package_bundle: KeyPackageBundle,
-    ) -> MlsGroup;
+    ) -> Self;
     /// Join a group from a Welcome message
     fn new_from_welcome(
         welcome: Welcome,

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -16,7 +16,7 @@
 
 use crate::ciphersuite::{signable::*, *};
 use crate::codec::*;
-use crate::config::ProtocolVersion;
+use crate::config::Config;
 use crate::extensions::{Extension, RatchetTreeExtension};
 use crate::framing::*;
 use crate::group::mls_group::*;
@@ -203,12 +203,12 @@ impl MlsGroup {
                 })
                 .collect();
             // Create welcome message
-            let welcome = Welcome {
-                version: ProtocolVersion::Mls10,
-                cipher_suite: self.ciphersuite,
+            let welcome = Welcome::new(
+                Config::supported_versions()[0],
+                self.ciphersuite.get_name(),
                 secrets,
                 encrypted_group_info,
-            };
+            );
             Ok((mls_plaintext, Some(welcome)))
         } else {
             Ok((mls_plaintext, None))

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -44,7 +44,11 @@ pub struct MlsGroup {
 }
 
 impl Api for MlsGroup {
-    fn new(id: &[u8], ciphersuite: Ciphersuite, key_package_bundle: KeyPackageBundle) -> MlsGroup {
+    fn new(
+        id: &[u8],
+        ciphersuite_name: CiphersuiteName,
+        key_package_bundle: KeyPackageBundle,
+    ) -> MlsGroup {
         let group_id = GroupId { value: id.to_vec() };
         let epoch_secrets = EpochSecrets::new();
         let secret_tree = SecretTree::new(&epoch_secrets.encryption_secret, LeafIndex::from(1u32));
@@ -53,7 +57,7 @@ impl Api for MlsGroup {
             key_package_bundle.key_package,
         );
         let kpb = KeyPackageBundle::from_values(key_package, private_key);
-        let tree = RatchetTree::new(ciphersuite, kpb);
+        let tree = RatchetTree::new(ciphersuite_name, kpb);
         let group_context = GroupContext {
             group_id,
             epoch: GroupEpoch(0),
@@ -62,7 +66,7 @@ impl Api for MlsGroup {
         };
         let interim_transcript_hash = vec![];
         MlsGroup {
-            ciphersuite,
+            ciphersuite: Ciphersuite::new(ciphersuite_name),
             group_context,
             generation: 0,
             epoch_secrets,

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -70,7 +70,7 @@ impl MlsGroup {
         )?;
 
         // Verify tree hash
-        if tree.compute_tree_hash() != &group_info.tree_hash[..] {
+        if tree.compute_tree_hash() != group_info.tree_hash {
             return Err(WelcomeError::TreeHashMismatch);
         }
 
@@ -137,7 +137,7 @@ impl MlsGroup {
             Err(WelcomeError::ConfirmationTagMismatch)
         } else {
             Ok(MlsGroup {
-                ciphersuite: ciphersuite.clone(),
+                ciphersuite,
                 group_context,
                 generation: 0,
                 epoch_secrets,

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -28,7 +28,8 @@ impl MlsGroup {
         nodes_option: Option<Vec<Option<Node>>>,
         key_package_bundle: KeyPackageBundle,
     ) -> Result<Self, WelcomeError> {
-        let ciphersuite = welcome.cipher_suite;
+        let ciphersuite_name = welcome.get_ciphersuite();
+        let ciphersuite = Ciphersuite::new(ciphersuite_name);
         let (private_key, key_package) = (
             key_package_bundle.private_key,
             key_package_bundle.key_package,
@@ -36,13 +37,13 @@ impl MlsGroup {
 
         // Find key_package in welcome secrets
         let egs = if let Some(egs) =
-            Self::find_key_package_from_welcome_secrets(&key_package, &welcome.secrets)
+            Self::find_key_package_from_welcome_secrets(&key_package, welcome.get_secrets_ref())
         {
             egs
         } else {
             return Err(WelcomeError::JoinerSecretNotFound);
         };
-        if &ciphersuite != key_package.get_cipher_suite() {
+        if ciphersuite_name != key_package.get_cipher_suite() {
             return Err(WelcomeError::CiphersuiteMismatch);
         }
 
@@ -51,7 +52,7 @@ impl MlsGroup {
             &ciphersuite,
             &egs,
             &private_key,
-            &welcome.encrypted_group_info,
+            welcome.get_encrypted_group_info_ref(),
         )?;
 
         // Build the ratchet tree
@@ -63,7 +64,7 @@ impl MlsGroup {
         };
 
         let mut tree = RatchetTree::new_from_nodes(
-            ciphersuite,
+            ciphersuite_name,
             KeyPackageBundle::from_values(key_package, private_key),
             &nodes,
         )?;
@@ -136,7 +137,7 @@ impl MlsGroup {
             Err(WelcomeError::ConfirmationTagMismatch)
         } else {
             Ok(MlsGroup {
-                ciphersuite: welcome.cipher_suite,
+                ciphersuite: ciphersuite.clone(),
                 group_context,
                 generation: 0,
                 epoch_secrets,

--- a/src/key_packages/codec.rs
+++ b/src/key_packages/codec.rs
@@ -11,14 +11,14 @@ impl Codec for KeyPackage {
 
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let protocol_version = ProtocolVersion::decode(cursor)?;
-        let cipher_suite = Ciphersuite::decode(cursor)?;
+        let cipher_suite_name = CiphersuiteName::decode(cursor)?;
         let hpke_init_key = HPKEPublicKey::decode(cursor)?;
         let credential = Credential::decode(cursor)?;
         let extensions = extensions_vec_from_cursor(cursor)?;
         let signature = Signature::decode(cursor)?;
         let kp = KeyPackage {
             protocol_version,
-            cipher_suite,
+            cipher_suite: cipher_suite_name,
             hpke_init_key,
             credential,
             extensions,

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -29,7 +29,7 @@ mod test_key_packages;
 #[derive(Debug, Clone, PartialEq)]
 pub struct KeyPackage {
     protocol_version: ProtocolVersion,
-    cipher_suite: Ciphersuite,
+    cipher_suite: CiphersuiteName,
     hpke_init_key: HPKEPublicKey,
     credential: Credential,
     extensions: Vec<Box<dyn Extension>>,
@@ -44,16 +44,17 @@ impl KeyPackage {
     /// Create a new key package but only with the given `extensions` for the
     /// given `ciphersuite` and `identity`, and the initial HPKE key pair `init_key`.
     fn new(
-        ciphersuite: Ciphersuite,
+        ciphersuite_name: CiphersuiteName,
         hpke_init_key: HPKEPublicKey,
         signature_key: &SignaturePrivateKey,
         credential: Credential,
         extensions: Vec<Box<dyn Extension>>,
     ) -> Self {
+        let ciphersuite = Ciphersuite::new(ciphersuite_name);
         let mut key_package = Self {
             // TODO: #85 Take from global config.
             protocol_version: ProtocolVersion::default(),
-            cipher_suite: ciphersuite,
+            cipher_suite: ciphersuite_name,
             hpke_init_key,
             credential,
             extensions,
@@ -109,7 +110,7 @@ impl KeyPackage {
     /// Compute the hash of the encoding of this key package.
     pub(crate) fn hash(&self) -> Vec<u8> {
         let bytes = self.encode_detached().unwrap();
-        self.cipher_suite.hash(&bytes)
+        Ciphersuite::new(self.cipher_suite).hash(&bytes)
     }
 
     /// Get a reference to the extension of `extension_type`.
@@ -160,8 +161,8 @@ impl KeyPackage {
     }
 
     /// Get a reference to the `Ciphersuite`.
-    pub(crate) fn get_cipher_suite(&self) -> &Ciphersuite {
-        &self.cipher_suite
+    pub(crate) fn get_cipher_suite(&self) -> CiphersuiteName {
+        self.cipher_suite
     }
 
     /// Get a reference to the extensions of this key package.
@@ -202,13 +203,19 @@ impl KeyPackageBundle {
     ///
     /// Returns a new `KeyPackageBundle`.
     pub fn new(
-        ciphersuite: &Ciphersuite,
+        ciphersuite_name: CiphersuiteName,
         signature_key: &SignaturePrivateKey,
         credential: Credential, // FIXME: must be reference
         extensions: Vec<Box<dyn Extension>>,
     ) -> Self {
-        let keypair = ciphersuite.new_hpke_keypair();
-        Self::new_with_keypair(&ciphersuite, signature_key, credential, extensions, keypair)
+        let keypair = Ciphersuite::new(ciphersuite_name).new_hpke_keypair();
+        Self::new_with_keypair(
+            ciphersuite_name,
+            signature_key,
+            credential,
+            extensions,
+            keypair,
+        )
     }
 
     /// Create a new `KeyPackageBundle` for the given `ciphersuite`, `identity`,
@@ -216,7 +223,7 @@ impl KeyPackageBundle {
     ///
     /// Returns a new `KeyPackageBundle`.
     pub fn new_with_keypair(
-        ciphersuite: &Ciphersuite,
+        ciphersuite_name: CiphersuiteName,
         signature_key: &SignaturePrivateKey,
         credential: Credential,
         extensions: Vec<Box<dyn Extension>>,
@@ -229,7 +236,7 @@ impl KeyPackageBundle {
         let (private_key, public_key) = key_pair.into_keys();
         final_extensions.extend_from_slice(&extensions);
         let key_package = KeyPackage::new(
-            *ciphersuite,
+            ciphersuite_name,
             public_key,
             signature_key,
             credential,

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -3,14 +3,14 @@ use crate::{extensions::LifetimeExtension, key_packages::*};
 
 #[test]
 fn generate_key_package() {
-    let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let signature_keypair = ciphersuite.new_signature_keypair();
     let identity =
         Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
     let credential = Credential::Basic(BasicCredential::from(&identity));
     let kpb = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         signature_keypair.get_private_key(),
         credential,
         vec![],
@@ -21,7 +21,7 @@ fn generate_key_package() {
     // Now with a lifetime the key package should be valid.
     let lifetime_extension = Box::new(LifetimeExtension::new(60));
     let kpb = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         signature_keypair.get_private_key(),
         Credential::Basic(BasicCredential::from(&identity)),
         vec![lifetime_extension],
@@ -32,7 +32,7 @@ fn generate_key_package() {
     // Now we add an invalid lifetime.
     let lifetime_extension = Box::new(LifetimeExtension::new(0));
     let kpb = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         signature_keypair.get_private_key(),
         Credential::Basic(BasicCredential::from(&identity)),
         vec![lifetime_extension],
@@ -43,14 +43,14 @@ fn generate_key_package() {
 
 #[test]
 fn test_codec() {
-    let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let signature_keypair = ciphersuite.new_signature_keypair();
     let identity =
         Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
     let credential = Credential::Basic(BasicCredential::from(&identity));
     let kpb = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         signature_keypair.get_private_key(),
         credential,
         Vec::new(),

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -26,6 +26,9 @@ use std::fmt;
 pub(crate) mod proposals;
 use proposals::*;
 
+#[cfg(test)]
+mod test_welcome;
+
 #[derive(Debug)]
 pub enum MessageError {
     UnknownOperation,
@@ -268,7 +271,7 @@ impl Codec for GroupSecrets {
     // }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct EncryptedGroupSecrets {
     pub key_package_hash: Vec<u8>,
     pub encrypted_group_secrets: HpkeCiphertext,
@@ -280,17 +283,17 @@ impl Codec for EncryptedGroupSecrets {
         self.encrypted_group_secrets.encode(buffer)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let key_package_hash = decode_vec(VecSize::VecU8, cursor)?;
-    //     let encrypted_group_secrets = HpkeCiphertext::decode(cursor)?;
-    //     Ok(EncryptedGroupSecrets {
-    //         key_package_hash,
-    //         encrypted_group_secrets,
-    //     })
-    // }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let key_package_hash = decode_vec(VecSize::VecU8, cursor)?;
+        let encrypted_group_secrets = HpkeCiphertext::decode(cursor)?;
+        Ok(EncryptedGroupSecrets {
+            key_package_hash,
+            encrypted_group_secrets,
+        })
+    }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Welcome {
     version: ProtocolVersion,
     cipher_suite: CiphersuiteName,
@@ -339,18 +342,18 @@ impl Codec for Welcome {
         encode_vec(VecSize::VecU32, buffer, &self.encrypted_group_info)?;
         Ok(())
     }
-    // fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-    //     let version = ProtocolVersion::decode(cursor)?;
-    //     let cipher_suite = Ciphersuite::decode(cursor)?;
-    //     let secrets = decode_vec(VecSize::VecU32, cursor)?;
-    //     let encrypted_group_info = decode_vec(VecSize::VecU32, cursor)?;
-    //     Ok(Welcome {
-    //         version,
-    //         cipher_suite,
-    //         secrets,
-    //         encrypted_group_info,
-    //     })
-    // }
+    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
+        let version = ProtocolVersion::decode(cursor)?;
+        let cipher_suite = CiphersuiteName::decode(cursor)?;
+        let secrets = decode_vec(VecSize::VecU32, cursor)?;
+        let encrypted_group_info = decode_vec(VecSize::VecU32, cursor)?;
+        Ok(Welcome {
+            version,
+            cipher_suite,
+            secrets,
+            encrypted_group_info,
+        })
+    }
 }
 
 pub type WelcomeBundle = (Welcome, ExtensionStruct);

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -292,10 +292,43 @@ impl Codec for EncryptedGroupSecrets {
 
 #[derive(Clone)]
 pub struct Welcome {
-    pub version: ProtocolVersion,
-    pub cipher_suite: Ciphersuite,
-    pub secrets: Vec<EncryptedGroupSecrets>,
-    pub encrypted_group_info: Vec<u8>,
+    version: ProtocolVersion,
+    cipher_suite: CiphersuiteName,
+    secrets: Vec<EncryptedGroupSecrets>,
+    encrypted_group_info: Vec<u8>,
+}
+
+impl Welcome {
+    /// Create a new welcome message from the provided data.
+    /// Note that secrets and the encrypted group info are consumed.
+    pub(crate) fn new(
+        version: ProtocolVersion,
+        cipher_suite: CiphersuiteName,
+        secrets: Vec<EncryptedGroupSecrets>,
+        encrypted_group_info: Vec<u8>,
+    ) -> Self {
+        Self {
+            version,
+            cipher_suite,
+            secrets,
+            encrypted_group_info,
+        }
+    }
+
+    /// Get a reference to the ciphersuite in this Welcome message.
+    pub(crate) fn get_ciphersuite(&self) -> CiphersuiteName {
+        self.cipher_suite
+    }
+
+    /// Get a reference to the ciphersuite in this Welcome message.
+    pub(crate) fn get_secrets_ref(&self) -> &[EncryptedGroupSecrets] {
+        &self.secrets
+    }
+
+    /// Get a reference to the encrypted group info.
+    pub(crate) fn get_encrypted_group_info_ref(&self) -> &[u8] {
+        &self.encrypted_group_info
+    }
 }
 
 impl Codec for Welcome {

--- a/src/messages/test_welcome.rs
+++ b/src/messages/test_welcome.rs
@@ -1,0 +1,122 @@
+use super::{EncryptedGroupSecrets, GroupInfo, Welcome};
+use crate::{
+    ciphersuite::{AeadKey, AeadNonce, Ciphersuite, HPKEKeyPair, Signature},
+    codec::*,
+    config::Config,
+    group::{GroupEpoch, GroupId},
+    tree::index::LeafIndex,
+    utils::*,
+};
+
+macro_rules! test_welcome_msg {
+    ($name:ident, $suite:expr, $version:expr) => {
+        #[test]
+        fn $name() {
+            // We use this dummy group info in all test cases.
+            let group_info = GroupInfo {
+                group_id: GroupId::random(),
+                epoch: GroupEpoch(123),
+                tree_hash: vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
+                confirmed_transcript_hash: vec![1, 1, 1],
+                interim_transcript_hash: vec![2, 2, 2],
+                extensions: Vec::new(),
+                confirmation_tag: vec![6, 6, 6],
+                signer_index: LeafIndex::from(8u32),
+                signature: Signature::new_empty(),
+            };
+
+            let ciphersuite = Ciphersuite::new($suite);
+
+            // Generate key and nonce for the symmetric cipher.
+            let welcome_key = AeadKey::from_slice(&randombytes(ciphersuite.aead_key_length()));
+            let welcome_nonce =
+                AeadNonce::from_slice(&randombytes(ciphersuite.aead_nonce_length()));
+
+            // Generate receiver key pair.
+            let receiver_key_pair = HPKEKeyPair::derive(&[1, 2, 3, 4], &ciphersuite);
+            let hpke_info = b"group info welcome test info";
+            let hpke_aad = b"group info welcome test aad";
+            let hpke_input = b"these should be the group secrets";
+            let secrets = vec![EncryptedGroupSecrets {
+                key_package_hash: vec![0, 0, 0, 0],
+                encrypted_group_secrets: ciphersuite.hpke_seal(
+                    &receiver_key_pair._get_public_key(),
+                    hpke_info,
+                    hpke_aad,
+                    hpke_input,
+                ),
+            }];
+
+            // Encrypt the group info.
+            let encrypted_group_info = ciphersuite
+                .aead_seal(
+                    &group_info.encode_detached().unwrap(),
+                    &[],
+                    &welcome_key,
+                    &welcome_nonce,
+                )
+                .unwrap();
+
+            // Now build the welcome message.
+            let msg = Welcome::new($version, $suite, secrets, encrypted_group_info.clone());
+
+            // Encode, decode and re-assemble
+            let msg_encoded = msg.encode_detached().unwrap();
+            println!("encoded msg: {:?}", msg_encoded);
+            let mut cursor = Cursor::new(&msg_encoded);
+            let msg_decoded = Welcome::decode(&mut cursor).unwrap();
+
+            // Check that the welcome message is the same
+            assert_eq!(msg_decoded.version, $version);
+            assert_eq!(msg_decoded.cipher_suite, $suite);
+            for secret in msg_decoded.secrets {
+                assert_eq!(secret.key_package_hash, secret.key_package_hash);
+                let ptxt = ciphersuite.hpke_open(
+                    &secret.encrypted_group_secrets,
+                    receiver_key_pair._get_private_key(),
+                    hpke_info,
+                    hpke_aad,
+                );
+                assert_eq!(&hpke_input[..], &ptxt[..]);
+            }
+            assert_eq!(msg_decoded.encrypted_group_info, encrypted_group_info);
+        }
+    };
+}
+
+test_welcome_msg!(
+    test_welcome_1_1,
+    Config::supported_ciphersuites()[0],
+    Config::supported_versions()[0]
+);
+
+test_welcome_msg!(
+    test_welcome_2_1,
+    Config::supported_ciphersuites()[1],
+    Config::supported_versions()[0]
+);
+
+test_welcome_msg!(
+    test_welcome_3_1,
+    Config::supported_ciphersuites()[2],
+    Config::supported_versions()[0]
+);
+
+#[test]
+fn invalid_welcomes() {
+    // An almost good welcome message.
+    let bytes = [
+        2, 0, 2, 0, 0, 0, 90, 4, 0, 0, 0, 0, 0, 32, 183, 76, 159, 248, 180, 5, 79, 86, 242, 165,
+        206, 103, 47, 8, 110, 250, 81, 48, 206, 185, 186, 104, 220, 181, 245, 106, 134, 32, 97,
+        233, 141, 26, 0, 49, 13, 203, 68, 119, 97, 90, 172, 36, 170, 239, 80, 191, 63, 146, 177,
+        211, 151, 152, 93, 117, 192, 136, 96, 22, 168, 213, 67, 165, 244, 165, 183, 228, 88, 62,
+        232, 36, 220, 224, 93, 216, 155, 210, 167, 34, 112, 7, 73, 42, 2, 0, 0, 0, 71, 254, 148,
+        190, 32, 30, 92, 51, 15, 16, 11, 46, 196, 65, 132, 142, 111, 177, 115, 21, 218, 71, 51,
+        118, 228, 188, 12, 134, 23, 216, 51, 20, 138, 215, 232, 62, 216, 119, 242, 93, 164, 250,
+        100, 223, 214, 94, 85, 139, 159, 205, 193, 153, 181, 243, 139, 12, 78, 253, 200, 47, 207,
+        79, 86, 82, 63, 217, 126, 204, 178, 24, 199, 49,
+    ];
+    let mut cursor = Cursor::new(&bytes);
+    let msg = Welcome::decode(&mut cursor);
+    assert!(msg.is_err());
+}

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -67,7 +67,7 @@ pub struct RatchetTree {
 
 impl RatchetTree {
     /// Create a new empty `RatchetTree`.
-    pub(crate) fn new(ciphersuite: Ciphersuite, kpb: KeyPackageBundle) -> RatchetTree {
+    pub(crate) fn new(ciphersuite_name: CiphersuiteName, kpb: KeyPackageBundle) -> RatchetTree {
         let nodes = vec![Node {
             node_type: NodeType::Leaf,
             key_package: Some(kpb.get_key_package().clone()),
@@ -82,7 +82,7 @@ impl RatchetTree {
         );
 
         RatchetTree {
-            ciphersuite,
+            ciphersuite: Ciphersuite::new(ciphersuite_name),
             nodes,
             private_tree,
         }
@@ -91,7 +91,7 @@ impl RatchetTree {
     /// Generate a new `RatchetTree` from `Node`s with the client's key package
     /// bundle `kpb`.
     pub(crate) fn new_from_nodes(
-        ciphersuite: Ciphersuite,
+        ciphersuite_name: CiphersuiteName,
         kpb: KeyPackageBundle,
         node_options: &[Option<Node>],
     ) -> Result<RatchetTree, TreeError> {
@@ -127,6 +127,7 @@ impl RatchetTree {
             }
         }
 
+        let ciphersuite = Ciphersuite::new(ciphersuite_name);
         // Build private tree
         let direct_path =
             treemath::direct_path_root(own_node_index, NodeIndex::from(nodes.len()).into())

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -75,12 +75,13 @@ fn test_tree_hash() {
     use crate::creds::*;
     use crate::tree::*;
 
-    fn create_identity(id: &[u8], ciphersuite: &Ciphersuite) -> KeyPackageBundle {
+    fn create_identity(id: &[u8], ciphersuite_name: CiphersuiteName) -> KeyPackageBundle {
+        let ciphersuite = Ciphersuite::new(ciphersuite_name);
         let signature_keypair = ciphersuite.new_signature_keypair();
-        let identity = Identity::new(*ciphersuite, id.to_vec());
+        let identity = Identity::new(ciphersuite_name, id.to_vec());
         let credential = Credential::Basic(BasicCredential::from(&identity));
         let kbp = KeyPackageBundle::new(
-            &ciphersuite,
+            ciphersuite_name,
             signature_keypair.get_private_key(),
             credential,
             Vec::new(),
@@ -88,19 +89,18 @@ fn test_tree_hash() {
         kbp
     }
 
-    let csuite = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let ciphersuite = Ciphersuite::new(csuite);
-    let kbp = create_identity(b"Tree creator", &ciphersuite);
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+    let kbp = create_identity(b"Tree creator", ciphersuite_name);
 
     // Initialise tree
-    let mut tree = RatchetTree::new(ciphersuite, kbp);
+    let mut tree = RatchetTree::new(ciphersuite_name, kbp);
     let tree_hash = tree.compute_tree_hash();
     println!("Tree hash: {:?}", tree_hash);
 
     // Add 5 nodes to the tree.
     let mut nodes = Vec::new();
     for _ in 0..5 {
-        nodes.push(create_identity(b"Tree creator", &ciphersuite));
+        nodes.push(create_identity(b"Tree creator", ciphersuite_name));
     }
     let key_packages: Vec<KeyPackage> = nodes.iter().map(|kbp| kbp.key_package.clone()).collect();
     let _ = tree.add_nodes(&key_packages);

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -11,17 +11,17 @@ fn padding() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let id = vec![1, 2, 3];
-    let identity = Identity::new(ciphersuite, vec![1, 2, 3]);
+    let identity = Identity::new(ciphersuite_name, vec![1, 2, 3]);
     let signature_keypair = ciphersuite.new_signature_keypair();
     let credential = Credential::Basic(BasicCredential::from(&identity));
     let kpb = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         signature_keypair.get_private_key(),
         credential,
         Vec::new(),
     );
 
-    let mut group_alice = MlsGroup::new(&id, ciphersuite, kpb);
+    let mut group_alice = MlsGroup::new(&id, ciphersuite_name, kpb);
     const PADDING_SIZE: usize = 10;
 
     for _ in 0..100 {

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -6,13 +6,12 @@ use maelstrom::key_packages::*;
 
 #[test]
 fn create_commit_optional_path() {
-    let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let group_aad = b"Alice's test group";
 
     // Define identities
-    let alice_identity = Identity::new(ciphersuite, "Alice".into());
-    let bob_identity = Identity::new(ciphersuite, "Bob".into());
+    let alice_identity = Identity::new(ciphersuite_name, "Alice".into());
+    let bob_identity = Identity::new(ciphersuite_name, "Bob".into());
 
     // Define credentials
     let alice_credential = BasicCredential::from(&alice_identity);
@@ -20,14 +19,14 @@ fn create_commit_optional_path() {
 
     // Generate KeyPackages
     let alice_key_package_bundle = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(alice_credential.clone()), // TODO: this consumes the credential!
         Vec::new(),
     );
 
     let bob_key_package_bundle = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(bob_credential), // TODO: this consumes the credential!
         Vec::new(),
@@ -35,7 +34,7 @@ fn create_commit_optional_path() {
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
     let alice_update_key_package_bundle = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(alice_credential),
         Vec::new(),
@@ -44,7 +43,7 @@ fn create_commit_optional_path() {
 
     // Alice creates a group
     let group_id = [1, 2, 3, 4];
-    let group_alice_1234 = MlsGroup::new(&group_id, ciphersuite, alice_key_package_bundle);
+    let group_alice_1234 = MlsGroup::new(&group_id, ciphersuite_name, alice_key_package_bundle);
 
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
@@ -112,13 +111,12 @@ fn create_commit_optional_path() {
 }
 #[test]
 fn basic_group_setup() {
-    let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+    let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let group_aad = b"Alice's test group";
 
     // Define identities
-    let alice_identity = Identity::new(ciphersuite, "Alice".into());
-    let bob_identity = Identity::new(ciphersuite, "Bob".into());
+    let alice_identity = Identity::new(ciphersuite_name, "Alice".into());
+    let bob_identity = Identity::new(ciphersuite_name, "Bob".into());
 
     // Define credentials
     let alice_credential = BasicCredential::from(&alice_identity);
@@ -126,7 +124,7 @@ fn basic_group_setup() {
 
     // Generate KeyPackages
     let bob_key_package_bundle = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(bob_credential), // TODO: this consumes the credential!
         Vec::new(),
@@ -134,7 +132,7 @@ fn basic_group_setup() {
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
     let alice_key_package_bundle = KeyPackageBundle::new(
-        &ciphersuite,
+        ciphersuite_name,
         &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Credential::Basic(alice_credential),
         Vec::new(),
@@ -142,7 +140,7 @@ fn basic_group_setup() {
 
     // Alice creates a group
     let group_id = [1, 2, 3, 4];
-    let group_alice_1234 = MlsGroup::new(&group_id, ciphersuite, alice_key_package_bundle);
+    let group_alice_1234 = MlsGroup::new(&group_id, ciphersuite_name, alice_key_package_bundle);
 
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -25,7 +25,7 @@ macro_rules! key_package_generation {
                 Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
             let credential = Credential::Basic(BasicCredential::from(&identity));
             let kpb = KeyPackageBundle::new(
-                &ciphersuite,
+                $ciphersuite,
                 signature_keypair.get_private_key(),
                 credential,
                 Vec::new(),


### PR DESCRIPTION
There are two parts to this PR

Welcome messages cleanup and tests. This adds tests (`messages/test_welcome`) for welcome messages and makes the struct fields private.

Instead of passing around the entire ciphersuite (this should probably get a better name) we should usually use the ciphersuite name. This will make changing the ciphersuite easier.