### PR TITLE
node and leaf index refactoring, treemath refactoring

### DIFF
--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -4,11 +4,11 @@ use crate::codec::*;
 pub struct NodeIndex(u32);
 
 impl NodeIndex {
-    pub fn as_u32(self) -> u32 {
-        self.0
+    pub fn as_u32(&self) -> &u32 {
+        &self.0
     }
-    pub fn as_usize(self) -> usize {
-        self.0 as usize
+    pub fn as_usize(&self) -> &usize {
+        &(self.0 as usize)
     }
 }
 
@@ -27,6 +27,18 @@ impl From<usize> for NodeIndex {
 impl From<LeafIndex> for NodeIndex {
     fn from(node_index: LeafIndex) -> NodeIndex {
         NodeIndex(node_index.as_u32() * 2)
+    }
+}
+
+impl Into<u32> for NodeIndex {
+    fn into(self) -> u32 {
+        self.0
+    }
+}
+
+impl Into<usize> for NodeIndex {
+    fn into(self) -> usize {
+        self.0 as usize
     }
 }
 


### PR DESCRIPTION
While trying to refactor the code to adhere to the Rust API naming guidelines, I noticed that we're very generous with cloning of `LeafIndex` and `NodeIndex` structs. That's not much of a performance issue, I think, as they're just `u32` structs, but I tried to refactor `treemath.rs` and `index.rs` as an exercise in borrowing and uses of `as_`, `to_`, `into()`, `from(...)`, etc.

There are obviously still lots of errors in the rest of the code, this PR is just to get some early feedback.

In particular, I refactored treemath such that the inputs are now references and changed the functions of `NodeIndex` such that they adhere to the Rust API naming guide.

The next step would be to go over the rest of the code and figure out, where we only need references and where we actually need to clone.