### PR TITLE
bump evercrypt and enable arm on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rust:
 os:
   - linux
   - osx
+arch:
+  - amd64
+  - arm64
 
 matrix:
   allow_failures:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,16 @@ byteorder = "^1.3"
 lazy_static = "1.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", tag = "v0.0.1"}
-evercrypt = { version = "0.0.1" }
+hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", version = "0.0.2-dev2"}
+evercrypt = { version = "0.0.3-dev3" }
 
 [features]
 default = ["rust-crypto"]
 rust-crypto = ["evercrypt/rust-crypto-aes"]
+
+[patch.crates-io]
+evercrypt = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt" }
+evercrypt-sys = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt-sys" }
 
 [dev-dependencies]
 criterion = "^0.2"


### PR DESCRIPTION
* Moving to a dev version of evercrypt and hpke that support ARM.
* Adding ARM64 to CI (we don't have 32-bit arm unfortunately right now, but it should work as well)