### PR TITLE
Remove interim_transcript_hash from GroupInfo

### DIFF
--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -800,7 +800,6 @@ impl Codec for MLSPlaintextCommitContent {
 
 pub struct MLSPlaintextCommitAuthData {
     pub confirmation_tag: Vec<u8>,
-    pub signature: Vec<u8>,
 }
 
 impl MLSPlaintextCommitAuthData {
@@ -817,7 +816,14 @@ impl From<&MLSPlaintext> for MLSPlaintextCommitAuthData {
         };
         MLSPlaintextCommitAuthData {
             confirmation_tag: confirmation_tag.0.clone(),
-            signature: mls_plaintext.signature.as_slice().to_vec(),
+        }
+    }
+}
+
+impl From<&ConfirmationTag> for MLSPlaintextCommitAuthData {
+    fn from(confirmation_tag: &ConfirmationTag) -> Self {
+        MLSPlaintextCommitAuthData {
+            confirmation_tag: confirmation_tag.as_slice(),
         }
     }
 }
@@ -825,15 +831,10 @@ impl From<&MLSPlaintext> for MLSPlaintextCommitAuthData {
 impl Codec for MLSPlaintextCommitAuthData {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         encode_vec(VecSize::VecU8, buffer, &self.confirmation_tag)?;
-        encode_vec(VecSize::VecU16, buffer, &self.signature)?;
         Ok(())
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let confirmation_tag = decode_vec(VecSize::VecU8, cursor)?;
-        let signature = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(MLSPlaintextCommitAuthData {
-            confirmation_tag,
-            signature,
-        })
+        Ok(MLSPlaintextCommitAuthData { confirmation_tag })
     }
 }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -135,7 +135,7 @@ impl MlsGroup {
 
         let interim_transcript_hash = update_interim_transcript_hash(
             &ciphersuite,
-            &mls_plaintext,
+            &MLSPlaintextCommitAuthData::from(&mls_plaintext),
             &confirmed_transcript_hash,
         );
 

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -127,17 +127,11 @@ impl MlsGroup {
             let ratchet_tree_extension = public_tree.to_extension_struct();
             let tree_hash = ciphersuite.hash(ratchet_tree_extension.get_extension_data());
             // Create GroupInfo object
-            let interim_transcript_hash = update_interim_transcript_hash(
-                &ciphersuite,
-                &mls_plaintext,
-                &confirmed_transcript_hash,
-            );
             let mut group_info = GroupInfo {
                 group_id: provisional_group_context.group_id.clone(),
                 epoch: provisional_group_context.epoch,
                 tree_hash,
                 confirmed_transcript_hash,
-                interim_transcript_hash,
                 extensions: vec![],
                 confirmation_tag: confirmation_tag.as_slice(),
                 signer_index: sender_index,

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -315,10 +315,10 @@ fn update_confirmed_transcript_hash(
 
 fn update_interim_transcript_hash(
     ciphersuite: &Ciphersuite,
-    mls_plaintext: &MLSPlaintext,
+    mls_plaintext_commit_auth_data: &MLSPlaintextCommitAuthData,
     confirmed_transcript_hash: &[u8],
 ) -> Vec<u8> {
-    let commit_auth_data_bytes = &MLSPlaintextCommitAuthData::from(mls_plaintext).serialize();
+    let commit_auth_data_bytes = mls_plaintext_commit_auth_data.serialize();
     ciphersuite.hash(&[confirmed_transcript_hash, &commit_auth_data_bytes].concat())
 }
 

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -148,7 +148,7 @@ pub struct GroupInfo {
     pub epoch: GroupEpoch,
     pub tree_hash: Vec<u8>,
     pub confirmed_transcript_hash: Vec<u8>,
-    pub interim_transcript_hash: Vec<u8>,
+    //pub interim_transcript_hash: Vec<u8>,
     pub extensions: Vec<Box<dyn Extension>>,
     pub confirmation_tag: Vec<u8>,
     pub signer_index: LeafIndex,
@@ -162,7 +162,7 @@ impl GroupInfo {
         let epoch = GroupEpoch::decode(&mut cursor)?;
         let tree_hash = decode_vec(VecSize::VecU8, &mut cursor)?;
         let confirmed_transcript_hash = decode_vec(VecSize::VecU8, &mut cursor)?;
-        let interim_transcript_hash = decode_vec(VecSize::VecU8, &mut cursor)?;
+        //let interim_transcript_hash = decode_vec(VecSize::VecU8, &mut cursor)?;
         let extensions = extensions_vec_from_cursor(&mut cursor)?;
         let confirmation_tag = decode_vec(VecSize::VecU8, &mut cursor)?;
         let signer_index = LeafIndex::from(u32::decode(&mut cursor)?);
@@ -172,7 +172,7 @@ impl GroupInfo {
             epoch,
             tree_hash,
             confirmed_transcript_hash,
-            interim_transcript_hash,
+            //interim_transcript_hash,
             extensions,
             confirmation_tag,
             signer_index,
@@ -218,7 +218,7 @@ impl Signable for GroupInfo {
         self.epoch.encode(buffer)?;
         encode_vec(VecSize::VecU8, buffer, &self.tree_hash)?;
         encode_vec(VecSize::VecU8, buffer, &self.confirmed_transcript_hash)?;
-        encode_vec(VecSize::VecU8, buffer, &self.interim_transcript_hash)?;
+        //encode_vec(VecSize::VecU8, buffer, &self.interim_transcript_hash)?;
         // Get extensions encoded. We need to build a Vec::<ExtensionStruct> first.
         let encoded_extensions: Vec<ExtensionStruct> = self
             .extensions

--- a/src/messages/mod.rs
+++ b/src/messages/mod.rs
@@ -106,7 +106,6 @@ pub struct GroupInfo {
     pub epoch: GroupEpoch,
     pub tree_hash: Vec<u8>,
     pub confirmed_transcript_hash: Vec<u8>,
-    //pub interim_transcript_hash: Vec<u8>,
     pub extensions: Vec<Box<dyn Extension>>,
     pub confirmation_tag: Vec<u8>,
     pub signer_index: LeafIndex,
@@ -120,7 +119,6 @@ impl GroupInfo {
         let epoch = GroupEpoch::decode(&mut cursor)?;
         let tree_hash = decode_vec(VecSize::VecU8, &mut cursor)?;
         let confirmed_transcript_hash = decode_vec(VecSize::VecU8, &mut cursor)?;
-        //let interim_transcript_hash = decode_vec(VecSize::VecU8, &mut cursor)?;
         let extensions = extensions_vec_from_cursor(&mut cursor)?;
         let confirmation_tag = decode_vec(VecSize::VecU8, &mut cursor)?;
         let signer_index = LeafIndex::from(u32::decode(&mut cursor)?);
@@ -130,7 +128,6 @@ impl GroupInfo {
             epoch,
             tree_hash,
             confirmed_transcript_hash,
-            //interim_transcript_hash,
             extensions,
             confirmation_tag,
             signer_index,
@@ -176,7 +173,6 @@ impl Signable for GroupInfo {
         self.epoch.encode(buffer)?;
         encode_vec(VecSize::VecU8, buffer, &self.tree_hash)?;
         encode_vec(VecSize::VecU8, buffer, &self.confirmed_transcript_hash)?;
-        //encode_vec(VecSize::VecU8, buffer, &self.interim_transcript_hash)?;
         // Get extensions encoded. We need to build a Vec::<ExtensionStruct> first.
         let encoded_extensions: Vec<ExtensionStruct> = self
             .extensions

--- a/src/messages/test_welcome.rs
+++ b/src/messages/test_welcome.rs
@@ -18,7 +18,6 @@ macro_rules! test_welcome_msg {
                 epoch: GroupEpoch(123),
                 tree_hash: vec![1, 2, 3, 4, 5, 6, 7, 8, 9],
                 confirmed_transcript_hash: vec![1, 1, 1],
-                interim_transcript_hash: vec![2, 2, 2],
                 extensions: Vec::new(),
                 confirmation_tag: vec![6, 6, 6],
                 signer_index: LeafIndex::from(8u32),


### PR DESCRIPTION
This PR addresses a spec change and removes the `interim_transcript_hash` from `GroupInfo`. 