### PR TITLE
use hpke keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 uuid = { version = "0.8", features = ["v4"] }
-rayon = "^1.3"
 rand = "^0.7"
 byteorder = "^1.3"
 lazy_static = "1.4"

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -94,33 +94,6 @@ impl Codec for Signature {
     }
 }
 
-impl Codec for HPKEKeyPair {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.private_key.encode(buffer)?;
-        self.public_key.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let public_key = HPKEPublicKey::decode(cursor)?;
-        let private_key = HPKEPrivateKey::decode(cursor)?;
-        Ok(Self {
-            private_key,
-            public_key,
-        })
-    }
-}
-
-impl Codec for HPKEPrivateKey {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU16, buffer, &self.value)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let inner = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(Self { value: inner })
-    }
-}
-
 impl Codec for HPKEPublicKey {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         encode_vec(VecSize::VecU16, buffer, self.as_slice())?;
@@ -128,7 +101,7 @@ impl Codec for HPKEPublicKey {
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
         let inner = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(Self { value: inner })
+        Ok(Self::new(inner))
     }
 }
 

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -110,7 +110,7 @@ pub struct SignatureKeypair {
     public_key: SignaturePublicKey,
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct Ciphersuite {
     name: CiphersuiteName,
     signature: SignatureMode,
@@ -170,7 +170,7 @@ impl Ciphersuite {
             Err(e) => panic!("Key generation really shouldn't fail. {:?}", e),
         };
         SignatureKeypair {
-            ciphersuite: *self,
+            ciphersuite: self.clone(),
             private_key: SignaturePrivateKey { value: sk.to_vec() },
             public_key: SignaturePublicKey { value: pk.to_vec() },
         }

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -198,7 +198,7 @@ impl Codec for Credential {
 }
 
 // TODO: Drop ciphersuite
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct BasicCredential {
     pub identity: Vec<u8>,
     pub ciphersuite: Ciphersuite,
@@ -216,7 +216,7 @@ impl From<&Identity> for BasicCredential {
     fn from(identity: &Identity) -> Self {
         BasicCredential {
             identity: identity.id.clone(),
-            ciphersuite: identity.ciphersuite,
+            ciphersuite: identity.ciphersuite.clone(),
             public_key: identity.keypair.get_public_key().clone(),
         }
     }
@@ -238,6 +238,12 @@ impl Codec for BasicCredential {
             ciphersuite,
             public_key,
         })
+    }
+}
+
+impl PartialEq for BasicCredential {
+    fn eq(&self, other: &Self) -> bool {
+        self.identity == other.identity && self.public_key == other.public_key
     }
 }
 

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -24,7 +24,6 @@ use crate::group::*;
 use crate::messages::*;
 use crate::tree::treemath;
 use crate::utils::*;
-use rayon::prelude::*;
 
 impl MlsGroup {
     pub(crate) fn create_commit_internal(
@@ -187,7 +186,7 @@ impl MlsGroup {
             }
             // Encrypt group secrets
             let secrets = plaintext_secrets
-                .par_iter()
+                .iter()
                 .map(|(init_key, bytes, key_package_hash)| {
                     let encrypted_group_secrets = ciphersuite.hpke_seal(init_key, &[], &[], bytes);
                     EncryptedGroupSecrets {

--- a/src/key_packages/codec.rs
+++ b/src/key_packages/codec.rs
@@ -34,20 +34,3 @@ impl Codec for KeyPackage {
         Ok(kp)
     }
 }
-
-impl Codec for KeyPackageBundle {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.key_package.encode(buffer)?;
-        self.private_key.encode(buffer)?;
-        Ok(())
-    }
-
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let key_package = KeyPackage::decode(cursor)?;
-        let private_key = HPKEPrivateKey::decode(cursor)?;
-        Ok(KeyPackageBundle {
-            key_package,
-            private_key,
-        })
-    }
-}

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -265,7 +265,7 @@ impl KeyPackageBundle {
         let mut final_extensions: Vec<Box<dyn Extension>> =
             vec![Box::new(CapabilitiesExtension::default())];
 
-        let (private_key, public_key) = key_pair.into_keys();
+        let (private_key, public_key) = key_pair.to_keys();
         final_extensions.extend_from_slice(&extensions);
         let key_package = KeyPackage::new(
             ciphersuite_name,

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -46,8 +46,11 @@ fn test_codec() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let signature_keypair = ciphersuite.new_signature_keypair();
-    let identity =
-        Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
+    let identity = Identity::new_with_keypair(
+        ciphersuite.clone(),
+        vec![1, 2, 3],
+        signature_keypair.clone(),
+    );
     let credential = Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
     let mut kpb = KeyPackageBundle::new(
         ciphersuite_name,
@@ -79,8 +82,11 @@ fn key_package_id_extension() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
     let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let signature_keypair = ciphersuite.new_signature_keypair();
-    let identity =
-        Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
+    let identity = Identity::new_with_keypair(
+        ciphersuite.clone(),
+        vec![1, 2, 3],
+        signature_keypair.clone(),
+    );
     let credential = Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
     let mut kpb = KeyPackageBundle::new(
         ciphersuite_name,

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -57,7 +57,7 @@ fn test_codec() {
     );
 
     // Encode and decode the key package.
-    let enc = kpb.encode_detached().unwrap();
+    let enc = kpb.get_key_package().encode_detached().unwrap();
 
     // Decoding fails because this is not a valid key package
     let kp = KeyPackage::decode(&mut Cursor::new(&enc));
@@ -67,7 +67,7 @@ fn test_codec() {
     let kp = kpb.get_key_package_ref_mut();
     kp.add_extension(Box::new(LifetimeExtension::new(60)));
     kp.sign(&ciphersuite, signature_keypair.get_private_key());
-    let enc = kpb.encode_detached().unwrap();
+    let enc = kpb.get_key_package().encode_detached().unwrap();
 
     // Now it's valid.
     let kp = KeyPackage::decode(&mut Cursor::new(&enc)).unwrap();

--- a/src/messages/test_welcome.rs
+++ b/src/messages/test_welcome.rs
@@ -1,6 +1,6 @@
 use super::{EncryptedGroupSecrets, GroupInfo, Welcome};
 use crate::{
-    ciphersuite::{AeadKey, AeadNonce, Ciphersuite, HPKEKeyPair, Signature},
+    ciphersuite::{AeadKey, AeadNonce, Ciphersuite, Signature},
     codec::*,
     config::Config,
     group::{GroupEpoch, GroupId},
@@ -33,14 +33,14 @@ macro_rules! test_welcome_msg {
                 AeadNonce::from_slice(&randombytes(ciphersuite.aead_nonce_length()));
 
             // Generate receiver key pair.
-            let receiver_key_pair = HPKEKeyPair::derive(&[1, 2, 3, 4], &ciphersuite);
+            let receiver_key_pair = ciphersuite.derive_hpke_keypair(&[1, 2, 3, 4]);
             let hpke_info = b"group info welcome test info";
             let hpke_aad = b"group info welcome test aad";
             let hpke_input = b"these should be the group secrets";
             let secrets = vec![EncryptedGroupSecrets {
                 key_package_hash: vec![0, 0, 0, 0],
                 encrypted_group_secrets: ciphersuite.hpke_seal(
-                    &receiver_key_pair._get_public_key(),
+                    receiver_key_pair.get_public_key_ref(),
                     hpke_info,
                     hpke_aad,
                     hpke_input,
@@ -73,7 +73,7 @@ macro_rules! test_welcome_msg {
                 assert_eq!(secret.key_package_hash, secret.key_package_hash);
                 let ptxt = ciphersuite.hpke_open(
                     &secret.encrypted_group_secrets,
-                    receiver_key_pair._get_private_key(),
+                    receiver_key_pair.get_private_key_ref(),
                     hpke_info,
                     hpke_aad,
                 );

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -406,7 +406,7 @@ impl RatchetTree {
     ) -> Result<(CommitSecret, Option<UpdatePath>, Option<PathSecrets>), TreeError> {
         // Generate new keypair
         let own_index = self.get_own_node_index();
-        let (private_key, public_key) = self.ciphersuite.new_hpke_keypair().into_keys();
+        let (private_key, public_key) = self.ciphersuite.new_hpke_keypair().to_keys();
 
         // Replace the init key in the current KeyPackage
         let key_package_bundle = {

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -425,7 +425,7 @@ impl RatchetTree {
         )?;
 
         // Compute the parent hash extension and update the KeyPackage
-        let csuite = self.ciphersuite;
+        let csuite = self.ciphersuite.clone();
         let parent_hash = self.compute_parent_hash(own_index);
         let key_package = self.get_own_key_package_ref_mut();
         key_package.update_parent_hash(&parent_hash);

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -3,7 +3,7 @@
 //!
 
 use super::{index::NodeIndex, path_keys::PathKeys, TreeError};
-use crate::ciphersuite::{Ciphersuite, HPKEKeyPair, HPKEPrivateKey, HPKEPublicKey};
+use crate::ciphersuite::{Ciphersuite, HPKEPrivateKey, HPKEPublicKey};
 use crate::codec::{Codec, CodecError};
 use crate::messages::CommitSecret;
 use crate::schedule::hkdf_expand_label;
@@ -204,8 +204,8 @@ impl PrivateTree {
         // Derive key pairs for all nodes in the direct path.
         for path_secret in self.path_secrets.iter() {
             let node_secret = hkdf_expand_label(ciphersuite, &path_secret, "node", &[], hash_len);
-            let keypair = HPKEKeyPair::derive(&node_secret, ciphersuite);
-            let (private_key, public_key) = keypair.into_keys();
+            let keypair = ciphersuite.derive_hpke_keypair(&node_secret);
+            let (private_key, public_key) = keypair.to_keys();
             public_keys.push(public_key);
             private_keys.push(private_key);
         }

--- a/src/tree/test_path_keys.rs
+++ b/src/tree/test_path_keys.rs
@@ -9,7 +9,7 @@ use crate::ciphersuite::*;
 #[test]
 fn test_duplicate_index() {
     fn key() -> HPKEPrivateKey {
-        HPKEPrivateKey::from_slice(&[1, 2, 3, 4, 5, 6])
+        HPKEPrivateKey::new(vec![1, 2, 3, 4, 5, 6])
     }
     let path = [
         NodeIndex::from(1u32),
@@ -25,7 +25,7 @@ fn test_duplicate_index() {
 #[test]
 fn test_insert_retrieve() {
     fn key() -> HPKEPrivateKey {
-        HPKEPrivateKey::from_slice(&[1, 2, 3, 4, 5, 6])
+        HPKEPrivateKey::new(vec![1, 2, 3, 4, 5, 6])
     }
     let path = generate_path_u32(2001);
     let private_keys = (0..1000).map(|_| key()).collect();
@@ -36,10 +36,7 @@ fn test_insert_retrieve() {
     path_keys.add(private_keys, &path[0..1000]).unwrap();
     // The key we look for
     path_keys
-        .add(
-            vec![HPKEPrivateKey::from_slice(&[6, 6, 6])],
-            &path[1000..1001],
-        )
+        .add(vec![HPKEPrivateKey::new(vec![6, 6, 6])], &path[1000..1001])
         .unwrap();
     let private_keys = (0..1000).map(|_| key()).collect();
     // A couple more random keys

--- a/src/tree/test_private_tree.rs
+++ b/src/tree/test_private_tree.rs
@@ -10,7 +10,7 @@ use crate::{ciphersuite::*, utils::*};
 fn setup(len: usize) -> (Ciphersuite, HPKEPrivateKey, NodeIndex, Vec<NodeIndex>) {
     let ciphersuite =
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
-    let hpke_private_key = HPKEPrivateKey::from_slice(&randombytes(32));
+    let hpke_private_key = HPKEPrivateKey::new(randombytes(32));
     let own_index = NodeIndex::from(0u32);
     let direct_path = generate_path_u8(len);
 


### PR DESCRIPTION
* Remove hpke keys from ciphersuite and use keys provided by the hpke crate.
* Use a global HPKE instance in the ciphersuite.

This works towards cleaning up the ciphersuite #114 .

Replacing #124 