### PR TITLE
Change Api function names for compliance with the Naming Guidelines

### DIFF
--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -189,9 +189,9 @@ impl MLSCiphertext {
     ) -> MLSCiphertext {
         const PADDING_SIZE: usize = 10;
 
-        let ciphersuite = mls_group.get_ciphersuite();
-        let context = mls_group.get_context();
-        let epoch_secrets = mls_group.get_epoch_secrets();
+        let ciphersuite = mls_group.ciphersuite();
+        let context = mls_group.context();
+        let epoch_secrets = mls_group.epoch_secrets();
         let sender_data = MLSSenderData::new(mls_plaintext.sender.sender, generation);
         let sender_data_key_bytes = hkdf_expand_label(
             ciphersuite,

--- a/src/group/managed_group.rs
+++ b/src/group/managed_group.rs
@@ -75,8 +75,8 @@ impl ManagedGroup {
 
     pub fn get_members(&self) -> Vec<Credential> {
         let mut members = Vec::new();
-        for i in 0..self.group.get_tree().leaf_count().as_usize() {
-            let node = self.group.get_tree().nodes[NodeIndex::from(i).as_usize()].clone();
+        for i in 0..self.group.tree().leaf_count().as_usize() {
+            let node = self.group.tree().nodes[NodeIndex::from(i).as_usize()].clone();
             let credential = node.key_package.unwrap().get_credential().clone();
             members.push(credential);
         }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -29,7 +29,7 @@ impl MlsGroup {
         proposals: Vec<MLSPlaintext>,
         own_key_packages: Vec<KeyPackageBundle>,
     ) -> Result<(), ApplyCommitError> {
-        let ciphersuite = self.get_ciphersuite();
+        let ciphersuite = self.ciphersuite();
         let mut pending_kpbs = own_key_packages;
 
         // Verify epoch

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -44,7 +44,7 @@ impl MlsGroup {
 
         let proposal_id_list = proposal_queue.get_proposal_id_list();
 
-        let sender_index = self.get_sender_index();
+        let sender_index = self.sender_index();
         let mut provisional_tree = self.tree.borrow_mut();
 
         // Apply proposals to tree

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -33,13 +33,13 @@ impl MlsGroup {
         proposals: Vec<MLSPlaintext>,
         force_self_update: bool,
     ) -> CreateCommitResult {
-        let ciphersuite = self.get_ciphersuite();
+        let ciphersuite = self.ciphersuite();
         // Filter proposals
         let (proposal_queue, contains_own_updates) = ProposalQueue::filtered_proposals(
             ciphersuite,
             proposals,
-            LeafIndex::from(self.get_tree().get_own_node_index()),
-            self.get_tree().leaf_count(),
+            LeafIndex::from(self.tree().get_own_node_index()),
+            self.tree().leaf_count(),
         );
 
         let proposal_id_list = proposal_queue.get_proposal_id_list();
@@ -68,7 +68,7 @@ impl MlsGroup {
             (commit_secret, path_option, path_secrets)
         } else {
             // If path is not needed, return empty commit secret
-            let commit_secret = CommitSecret(zero(self.get_ciphersuite().hash_length()));
+            let commit_secret = CommitSecret(zero(self.ciphersuite().hash_length()));
             (commit_secret, None, None)
         };
         // Create commit message
@@ -80,7 +80,7 @@ impl MlsGroup {
         let mut provisional_epoch = self.group_context.epoch;
         provisional_epoch.increment();
         let confirmed_transcript_hash = update_confirmed_transcript_hash(
-            self.get_ciphersuite(),
+            self.ciphersuite(),
             &MLSPlaintextCommitContent::new(&self.group_context, sender_index, commit.clone()),
             &self.interim_transcript_hash,
         );
@@ -111,7 +111,7 @@ impl MlsGroup {
             aad,
             content,
             signature_key,
-            &self.get_context(),
+            &self.context(),
         );
         // Check if new members were added an create welcome message
         // TODO: Add support for extensions

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -104,7 +104,7 @@ impl Api for MlsGroup {
         let content = MLSPlaintextContentType::Proposal(proposal);
         MLSPlaintext::new(
             &self.ciphersuite,
-            self.get_sender_index(),
+            self.sender_index(),
             aad,
             content,
             signature_key,
@@ -127,7 +127,7 @@ impl Api for MlsGroup {
         let content = MLSPlaintextContentType::Proposal(proposal);
         MLSPlaintext::new(
             &self.ciphersuite,
-            self.get_sender_index(),
+            self.sender_index(),
             aad,
             content,
             signature_key,
@@ -152,7 +152,7 @@ impl Api for MlsGroup {
         let content = MLSPlaintextContentType::Proposal(proposal);
         MLSPlaintext::new(
             &self.ciphersuite,
-            self.get_sender_index(),
+            self.sender_index(),
             aad,
             content,
             signature_key,
@@ -199,7 +199,7 @@ impl Api for MlsGroup {
         let content = MLSPlaintextContentType::Application(msg.to_vec());
         let mls_plaintext = MLSPlaintext::new(
             &self.ciphersuite,
-            self.get_sender_index(),
+            self.sender_index(),
             aad,
             content,
             signature_key,
@@ -290,7 +290,7 @@ impl MlsGroup {
     pub fn tree(&self) -> Ref<RatchetTree> {
         self.tree.borrow()
     }
-    fn get_sender_index(&self) -> LeafIndex {
+    fn sender_index(&self) -> LeafIndex {
         self.tree.borrow().get_own_node_index().into()
     }
     pub(crate) fn ciphersuite(&self) -> &Ciphersuite {

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -108,7 +108,7 @@ impl Api for MlsGroup {
             aad,
             content,
             signature_key,
-            &self.get_context(),
+            &self.context(),
         )
     }
 
@@ -131,7 +131,7 @@ impl Api for MlsGroup {
             aad,
             content,
             signature_key,
-            &self.get_context(),
+            &self.context(),
         )
     }
 
@@ -156,7 +156,7 @@ impl Api for MlsGroup {
             aad,
             content,
             signature_key,
-            &self.get_context(),
+            &self.context(),
         )
     }
 
@@ -203,7 +203,7 @@ impl Api for MlsGroup {
             aad,
             content,
             signature_key,
-            &self.get_context(),
+            &self.context(),
         );
         self.encrypt(mls_plaintext)
     }
@@ -245,10 +245,10 @@ impl Api for MlsGroup {
     // Exporter
     fn export_secret(&self, label: &str, key_length: usize) -> Vec<u8> {
         mls_exporter(
-            self.get_ciphersuite(),
+            self.ciphersuite(),
             &self.epoch_secrets,
             label,
-            &self.get_context(),
+            &self.context(),
             key_length,
         )
     }
@@ -287,21 +287,21 @@ impl Codec for MlsGroup {
 }
 
 impl MlsGroup {
-    pub fn get_tree(&self) -> Ref<RatchetTree> {
+    pub fn tree(&self) -> Ref<RatchetTree> {
         self.tree.borrow()
     }
     fn get_sender_index(&self) -> LeafIndex {
         self.tree.borrow().get_own_node_index().into()
     }
-    pub(crate) fn get_ciphersuite(&self) -> &Ciphersuite {
+    pub(crate) fn ciphersuite(&self) -> &Ciphersuite {
         &self.ciphersuite
     }
 
-    pub(crate) fn get_context(&self) -> &GroupContext {
+    pub(crate) fn context(&self) -> &GroupContext {
         &self.group_context
     }
 
-    pub(crate) fn get_epoch_secrets(&self) -> &EpochSecrets {
+    pub(crate) fn epoch_secrets(&self) -> &EpochSecrets {
         &self.epoch_secrets
     }
 }


### PR DESCRIPTION
If #122 is meant only for the `Api` trait, then it's a no-op. In this PR, I have changed some of the `MlsGroup` implementation function names, as `MlsGroup` also implements the `Api`.

Fixes #122 (I think).

Naming Guidlines: https://rust-lang.github.io/api-guidelines/naming.html