### PR TITLE
init fuzzing infrastructure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,6 +88,11 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Nightly toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: nightly
     - name: Setup
       run: cargo install cargo-fuzz
     - name: Fuzz Welcome

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,3 +71,28 @@ jobs:
       uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+  fuzz:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          target
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    - name: Stable with fuzz
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        components: fuzz
+    - name: Fuzz Welcome
+      run: cargo fuzz run welcome_fuzz_decode_target -- -runs=100000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,11 +88,7 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Stable with fuzz
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        components: fuzz
+    - name: Setup
+      run: cargo install cargo-fuzz
     - name: Fuzz Welcome
       run: cargo fuzz run welcome_fuzz_decode_target -- -runs=100000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,26 +71,3 @@ jobs:
       uses: actions-rs/audit-check@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-  fuzz:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - macos-latest
-          - ubuntu-latest
-    runs-on: ${{ matrix.os }}
-    steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - uses: actions-rs/install@v0.1
-      with:
-        crate: cargo-fuzz
-        version: latest
-    - name: Fuzz Welcome
-      run: cargo fuzz run welcome_fuzz_decode_target -- -runs=100000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -88,12 +88,9 @@ jobs:
           ~/.cargo/git
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    - name: Nightly toolchain
-      uses: actions-rs/toolchain@v1
+    - uses: actions-rs/install@v0.1
       with:
-        profile: minimal
-        toolchain: nightly
-    - name: Setup
-      run: cargo install cargo-fuzz
+        crate: cargo-fuzz
+        version: latest
     - name: Fuzz Welcome
       run: cargo fuzz run welcome_fuzz_decode_target -- -runs=100000

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,36 @@
+
+[package]
+name = "maelstrom-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.3"
+
+[dependencies.maelstrom]
+path = ".."
+
+[patch.crates-io]
+evercrypt = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt" }
+evercrypt-sys = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt-sys" }
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "welcome_fuzz_decode_target"
+path = "fuzz_targets/welcome_fuzz_decode_target.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "decode_key_package_target"
+path = "fuzz_targets/decode_key_package_target.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decode_key_package_target.rs
+++ b/fuzz/fuzz_targets/decode_key_package_target.rs
@@ -1,0 +1,12 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use maelstrom::{
+    codec::{Codec, Cursor},
+    key_packages::KeyPackage,
+};
+
+fuzz_target!(|data: &[u8]| {
+    let mut cursor = Cursor::new(data);
+    let _ = KeyPackage::decode(&mut cursor);
+});

--- a/fuzz/fuzz_targets/welcome_fuzz_decode_target.rs
+++ b/fuzz/fuzz_targets/welcome_fuzz_decode_target.rs
@@ -1,0 +1,12 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+use maelstrom::{
+    codec::{Codec, Cursor},
+    messages::Welcome,
+};
+
+fuzz_target!(|data: &[u8]| {
+    let mut cursor = Cursor::new(data);
+    let _ = Welcome::decode(&mut cursor);
+});

--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -26,7 +26,7 @@ impl Codec for CiphersuiteName {
         Ok(())
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        Ok(CiphersuiteName::from(u16::decode(cursor)?))
+        Ok(CiphersuiteName::try_from(u16::decode(cursor)?)?)
     }
 }
 
@@ -36,9 +36,9 @@ impl Codec for Ciphersuite {
         Ok(())
     }
     fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        Ok(Ciphersuite::new(CiphersuiteName::from(u16::decode(
+        Ok(Ciphersuite::new(CiphersuiteName::try_from(u16::decode(
             cursor,
-        )?)))
+        )?)?))
     }
 }
 

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -134,7 +134,7 @@ impl Clone for Ciphersuite {
 impl Ciphersuite {
     /// Create a new ciphersuite from the given `name`.
     pub fn new(name: CiphersuiteName) -> Self {
-        let hpke_kem = get_kem_from_suite(&name);
+        let hpke_kem = get_kem_from_suite(&name).unwrap();
         let hpke_kdf = get_hpke_kdf_from_suite(&name);
         let hpke_aead = get_hpke_aead_from_suite(&name);
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use crate::errors::ConfigError;
+use crate::errors::{ConfigError, Error};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashMap;
 use std::convert::*;
@@ -29,6 +29,16 @@ impl From<ConfigError> for CodecError {
     // TODO: tbd in #83
     fn from(_e: ConfigError) -> CodecError {
         CodecError::DecodingError
+    }
+}
+
+impl From<Error> for CodecError {
+    // TODO: tbd in #83, also this direction shouldn't be necessary.
+    fn from(e: Error) -> CodecError {
+        match e {
+            Error::DecodingError => CodecError::DecodingError,
+            Error::UnsupportedCiphersuite => CodecError::DecodingError,
+        }
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,3 +12,9 @@ pub enum ConfigError {
     UnsupportedCiphersuite,
     ExpiredLifetimeExtension,
 }
+
+#[derive(Debug, PartialEq)]
+pub enum Error {
+    DecodingError,
+    UnsupportedCiphersuite,
+}


### PR DESCRIPTION
This PR adds the basic infrastructure for fuzzing in #154.
I'm skipping the GH action for spot fuzzing for now, the setup is a little weird. I'll add that later.

The key package fuzzer will quickly fail. This will need more work as sketched in the changes to ciphersuite already.
