### PR TITLE
Remove Identity in favor of CredentialBundle

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -26,22 +26,17 @@ use maelstrom::key_packages::*;
 
 fn criterion_kp_bundle(c: &mut Criterion) {
     c.bench_function("KeyPackage create bundle", |b| {
-        let ciphersuite = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-        let signature_keypair = Ciphersuite::new(ciphersuite).new_signature_keypair();
+        let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
+
         b.iter_with_setup(
             || {
-                let identity = Identity::new(ciphersuite, vec![1, 2, 3]);
-                Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)))
+                let id = vec![1, 2, 3];
+                CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap()
             },
-            |credential| {
-                KeyPackageBundle::new(
-                    ciphersuite,
-                    signature_keypair.get_private_key(),
-                    credential,
-                    Vec::new(),
-                );
+            |credential_bundle: CredentialBundle| {
+                KeyPackageBundle::new(ciphersuite_name, &credential_bundle, Vec::new());
             },
-        )
+        );
     });
 }
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -30,8 +30,8 @@ fn criterion_kp_bundle(c: &mut Criterion) {
 
         b.iter_with_setup(
             || {
-                let id = vec![1, 2, 3];
-                CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap()
+                CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, ciphersuite_name)
+                    .unwrap()
             },
             |credential_bundle: CredentialBundle| {
                 KeyPackageBundle::new(ciphersuite_name, &credential_bundle, Vec::new());

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -376,7 +376,7 @@ impl SignatureKeypair {
     }
 
     /// Get the private and public key objects
-    pub fn as_tuple(self) -> (SignaturePrivateKey, SignaturePublicKey) {
+    pub fn into_tuple(self) -> (SignaturePrivateKey, SignaturePublicKey) {
         (self.private_key, self.public_key)
     }
 }

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -374,6 +374,11 @@ impl SignatureKeypair {
     pub fn get_public_key(&self) -> &SignaturePublicKey {
         &self.public_key
     }
+
+    /// Get the private and public key objects
+    pub fn as_tuple(self) -> (SignaturePrivateKey, SignaturePublicKey) {
+        (self.private_key, self.public_key)
+    }
 }
 
 #[test]

--- a/src/ciphersuite/signable.rs
+++ b/src/ciphersuite/signable.rs
@@ -9,16 +9,12 @@ pub trait Signable: Sized {
     /// Sign the payload with the given `id`.
     ///
     /// Returns a `Signature`.
-    fn sign(
-        &mut self,
-        ciphersuite: &Ciphersuite,
-        signature_key: &SignaturePrivateKey,
-    ) -> Signature {
+    fn sign(&self, credential_bundle: &CredentialBundle) -> Signature {
         let payload = self.unsigned_payload().unwrap();
-        ciphersuite.sign(signature_key, &payload).unwrap()
+        credential_bundle.sign(&payload).unwrap()
     }
 
-    /// Verifies the payload against the given `id` and `signature`.
+    /// Verifies the payload against the given `credential` and `signature`.
     ///
     /// Returns a `true` if the signature is valid and `false` otherwise.
     fn verify(&self, credential: &Credential, signature: &Signature) -> bool {

--- a/src/ciphersuite/signable.rs
+++ b/src/ciphersuite/signable.rs
@@ -21,8 +21,8 @@ pub trait Signable: Sized {
     /// Verifies the payload against the given `id` and `signature`.
     ///
     /// Returns a `true` if the signature is valid and `false` otherwise.
-    fn verify(&self, id: &Identity, signature: &Signature) -> bool {
+    fn verify(&self, credential: &Credential, signature: &Signature) -> bool {
         let payload = self.unsigned_payload().unwrap();
-        id.verify(&payload, signature)
+        credential.verify(&payload, signature)
     }
 }

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -220,7 +220,7 @@ impl CredentialBundle {
         ciphersuite_name: CiphersuiteName,
     ) -> Result<Self, CredentialError> {
         let ciphersuite = Ciphersuite::new(ciphersuite_name);
-        let (private_key, public_key) = ciphersuite.new_signature_keypair().as_tuple();
+        let (private_key, public_key) = ciphersuite.new_signature_keypair().into_tuple();
         let mls_credential = match credential_type {
             CredentialType::Basic => BasicCredential {
                 identity,

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -96,11 +96,11 @@ pub enum CredentialType {
 impl TryFrom<u16> for CredentialType {
     type Error = &'static str;
 
-    fn try_from(value: u16) -> Result<Self, CredentialError> {
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
         match value {
             1 => Ok(CredentialType::Basic),
             2 => Ok(CredentialType::X509),
-            _ => Err(CredentialError::UnsupportedCredentialType),
+            _ => Err("Undefined CredentialType"),
         }
     }
 }

--- a/src/creds.rs
+++ b/src/creds.rs
@@ -222,13 +222,13 @@ impl CredentialBundle {
         let ciphersuite = Ciphersuite::new(ciphersuite_name);
         let (private_key, public_key) = ciphersuite.new_signature_keypair().as_tuple();
         let mls_credential = match credential_type {
-            CredentialType::Basic => Ok(BasicCredential {
+            CredentialType::Basic => BasicCredential {
                 identity,
                 ciphersuite,
                 public_key,
-            }),
-            _ => Err(CredentialError::UnsupportedCredentialType),
-        }?;
+            },
+            _ => return Err(CredentialError::UnsupportedCredentialType),
+        };
         let credential = Credential {
             credential_type,
             credential: MLSCredentialType::Basic(mls_credential),

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -49,11 +49,10 @@ pub struct MLSPlaintext {
 
 impl MLSPlaintext {
     pub fn new(
-        ciphersuite: &Ciphersuite,
         sender: LeafIndex,
         authenticated_data: &[u8],
         content: MLSPlaintextContentType,
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         context: &GroupContext,
     ) -> Self {
         let sender = Sender {
@@ -70,7 +69,7 @@ impl MLSPlaintext {
             signature: Signature::new_empty(),
         };
         let serialized_context = context.encode_detached().unwrap();
-        mls_plaintext.sign(ciphersuite, signature_key, Some(serialized_context));
+        mls_plaintext.sign(credential_bundle, Some(serialized_context));
         mls_plaintext
     }
     // XXX: Only used in tests right now.
@@ -97,12 +96,11 @@ impl MLSPlaintext {
     }
     pub fn sign(
         &mut self,
-        ciphersuite: &Ciphersuite,
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         serialized_context_option: Option<Vec<u8>>,
     ) {
         let signature_input = MLSPlaintextTBS::new_from(&self, serialized_context_option);
-        self.signature = signature_input.sign(ciphersuite, signature_key);
+        self.signature = signature_input.sign(credential_bundle);
     }
     pub fn verify(
         &self,
@@ -509,13 +507,9 @@ impl MLSPlaintextTBS {
             payload: mls_plaintext.content.clone(),
         }
     }
-    pub fn sign(
-        &self,
-        ciphersuite: &Ciphersuite,
-        signature_key: &SignaturePrivateKey,
-    ) -> Signature {
+    pub fn sign(&self, credential_bundle: &CredentialBundle) -> Signature {
         let bytes = self.encode_detached().unwrap();
-        ciphersuite.sign(signature_key, &bytes).unwrap()
+        credential_bundle.sign(&bytes).unwrap()
     }
     pub fn verify(&self, credential: &Credential, signature: &Signature) -> bool {
         let bytes = self.encode_detached().unwrap();

--- a/src/group/mls_group/api.rs
+++ b/src/group/mls_group/api.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
+use crate::creds::CredentialBundle;
 use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;
@@ -40,28 +41,28 @@ pub trait Api: Sized {
     fn create_add_proposal(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         joiner_key_package: KeyPackage,
     ) -> MLSPlaintext;
     /// Create an `UpdateProposal`
     fn create_update_proposal(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         key_package: KeyPackage,
     ) -> MLSPlaintext;
     /// Create a `RemoveProposal`
     fn create_remove_proposal(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         removed_index: LeafIndex,
     ) -> MLSPlaintext;
     /// Create a `Commit` and an optional `Welcome`
     fn create_commit(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         proposals: Vec<MLSPlaintext>,
         force_self_update: bool,
     ) -> CreateCommitResult;
@@ -79,7 +80,7 @@ pub trait Api: Sized {
         &mut self,
         aad: &[u8],
         msg: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
     ) -> MLSCiphertext;
 
     /// Encrypt an MLS message

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -17,6 +17,7 @@
 use crate::ciphersuite::{signable::*, *};
 use crate::codec::*;
 use crate::config::Config;
+use crate::creds::CredentialBundle;
 use crate::extensions::{Extension, RatchetTreeExtension};
 use crate::framing::*;
 use crate::group::mls_group::*;
@@ -29,7 +30,7 @@ impl MlsGroup {
     pub(crate) fn create_commit_internal(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         proposals: Vec<MLSPlaintext>,
         force_self_update: bool,
     ) -> CreateCommitResult {
@@ -63,7 +64,7 @@ impl MlsGroup {
         let (commit_secret, path, path_secrets_option) = if path_required {
             // If path is needed, compute path values
             let (commit_secret, path_option, path_secrets) = provisional_tree
-                .refresh_private_tree(signature_key, &self.group_context.serialize())
+                .refresh_private_tree(credential_bundle, &self.group_context.serialize())
                 .unwrap();
             (commit_secret, path_option, path_secrets)
         } else {
@@ -106,11 +107,10 @@ impl MlsGroup {
         // Create MLSPlaintext
         let content = MLSPlaintextContentType::Commit((commit, confirmation_tag.clone()));
         let mls_plaintext = MLSPlaintext::new(
-            ciphersuite,
             sender_index,
             aad,
             content,
-            signature_key,
+            credential_bundle,
             &self.context(),
         );
         // Check if new members were added an create welcome message
@@ -130,7 +130,7 @@ impl MlsGroup {
                 signer_index: sender_index,
                 signature: Signature::new_empty(),
             };
-            group_info.signature = group_info.sign(ciphersuite, signature_key);
+            group_info.signature = group_info.sign(credential_bundle);
             // Encrypt GroupInfo object
             let (welcome_key, welcome_nonce) =
                 compute_welcome_key_nonce(ciphersuite, &epoch_secret);

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -21,6 +21,7 @@ mod new_from_welcome;
 
 use crate::ciphersuite::*;
 use crate::codec::*;
+use crate::creds::CredentialBundle;
 use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;
@@ -94,7 +95,7 @@ impl Api for MlsGroup {
     fn create_add_proposal(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         joiner_key_package: KeyPackage,
     ) -> MLSPlaintext {
         let add_proposal = AddProposal {
@@ -103,11 +104,10 @@ impl Api for MlsGroup {
         let proposal = Proposal::Add(add_proposal);
         let content = MLSPlaintextContentType::Proposal(proposal);
         MLSPlaintext::new(
-            &self.ciphersuite,
             self.sender_index(),
             aad,
             content,
-            signature_key,
+            credential_bundle,
             &self.context(),
         )
     }
@@ -119,18 +119,17 @@ impl Api for MlsGroup {
     fn create_update_proposal(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         key_package: KeyPackage,
     ) -> MLSPlaintext {
         let update_proposal = UpdateProposal { key_package };
         let proposal = Proposal::Update(update_proposal);
         let content = MLSPlaintextContentType::Proposal(proposal);
         MLSPlaintext::new(
-            &self.ciphersuite,
             self.sender_index(),
             aad,
             content,
-            signature_key,
+            credential_bundle,
             &self.context(),
         )
     }
@@ -142,7 +141,7 @@ impl Api for MlsGroup {
     fn create_remove_proposal(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         removed_index: LeafIndex,
     ) -> MLSPlaintext {
         let remove_proposal = RemoveProposal {
@@ -151,11 +150,10 @@ impl Api for MlsGroup {
         let proposal = Proposal::Remove(remove_proposal);
         let content = MLSPlaintextContentType::Proposal(proposal);
         MLSPlaintext::new(
-            &self.ciphersuite,
             self.sender_index(),
             aad,
             content,
-            signature_key,
+            credential_bundle,
             &self.context(),
         )
     }
@@ -172,11 +170,11 @@ impl Api for MlsGroup {
     fn create_commit(
         &self,
         aad: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         proposals: Vec<MLSPlaintext>,
         force_self_update: bool,
     ) -> CreateCommitResult {
-        self.create_commit_internal(aad, signature_key, proposals, force_self_update)
+        self.create_commit_internal(aad, credential_bundle, proposals, force_self_update)
     }
 
     // Apply a Commit message
@@ -194,15 +192,14 @@ impl Api for MlsGroup {
         &mut self,
         aad: &[u8],
         msg: &[u8],
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
     ) -> MLSCiphertext {
         let content = MLSPlaintextContentType::Application(msg.to_vec());
         let mls_plaintext = MLSPlaintext::new(
-            &self.ciphersuite,
             self.sender_index(),
             aad,
             content,
-            signature_key,
+            credential_bundle,
             &self.context(),
         );
         self.encrypt(mls_plaintext)

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -62,8 +62,7 @@ impl KeyPackage {
     fn new(
         ciphersuite_name: CiphersuiteName,
         hpke_init_key: HPKEPublicKey,
-        signature_key: &SignaturePrivateKey,
-        credential: Credential,
+        credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
     ) -> Self {
         let ciphersuite = Ciphersuite::new(ciphersuite_name);
@@ -72,11 +71,11 @@ impl KeyPackage {
             protocol_version: ProtocolVersion::default(),
             cipher_suite: ciphersuite_name,
             hpke_init_key,
-            credential,
+            credential: credential_bundle.credential().clone(),
             extensions,
             signature: Signature::new_empty(),
         };
-        key_package.sign(&ciphersuite, signature_key);
+        key_package.sign(&ciphersuite, credential_bundle.signature_private_key());
         key_package
     }
 
@@ -262,8 +261,7 @@ impl KeyPackageBundle {
         let key_package = KeyPackage::new(
             ciphersuite_name,
             public_key,
-            credential_bundle.signature_private_key(),
-            credential_bundle.credential().clone(),
+            credential_bundle,
             final_extensions,
         );
         KeyPackageBundle {

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -236,18 +236,11 @@ impl KeyPackageBundle {
     /// Returns a new `KeyPackageBundle`.
     pub fn new(
         ciphersuite_name: CiphersuiteName,
-        signature_key: &SignaturePrivateKey,
-        credential: Credential, // FIXME: must be reference
+        credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
     ) -> Self {
         let keypair = Ciphersuite::new(ciphersuite_name).new_hpke_keypair();
-        Self::new_with_keypair(
-            ciphersuite_name,
-            signature_key,
-            credential,
-            extensions,
-            keypair,
-        )
+        Self::new_with_keypair(ciphersuite_name, credential_bundle, extensions, keypair)
     }
 
     /// Create a new `KeyPackageBundle` for the given `ciphersuite`, `identity`,
@@ -256,8 +249,7 @@ impl KeyPackageBundle {
     /// Returns a new `KeyPackageBundle`.
     pub fn new_with_keypair(
         ciphersuite_name: CiphersuiteName,
-        signature_key: &SignaturePrivateKey,
-        credential: Credential,
+        credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
         key_pair: HPKEKeyPair,
     ) -> Self {
@@ -270,8 +262,8 @@ impl KeyPackageBundle {
         let key_package = KeyPackage::new(
             ciphersuite_name,
             public_key,
-            signature_key,
-            credential,
+            credential_bundle.signature_private_key(),
+            credential_bundle.credential().clone(),
             final_extensions,
         );
         KeyPackageBundle {

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -74,7 +74,7 @@ impl KeyPackage {
             extensions,
             signature: Signature::new_empty(),
         };
-        key_package.sign_self(&credential_bundle);
+        key_package.sign(&credential_bundle);
         key_package
     }
 
@@ -213,7 +213,7 @@ impl KeyPackage {
     }
 
     /// Populate the `signature` field using the `credential_bundle`.
-    pub(crate) fn sign_self(&mut self, credential_bundle: &CredentialBundle) {
+    pub(crate) fn sign(&mut self, credential_bundle: &CredentialBundle) {
         let payload = &self.unsigned_payload().unwrap();
         self.signature = credential_bundle.sign(payload).unwrap();
     }

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
 
-use crate::ciphersuite::{signable::*, *};
+use crate::ciphersuite::*;
 use crate::codec::*;
 use crate::config::ProtocolVersion;
 use crate::creds::*;
@@ -194,14 +194,8 @@ impl KeyPackage {
         &self.extensions
     }
 
-    /// Populate the `signature` field using the `credential_bundle`.
-    pub(crate) fn sign_self(&mut self, credential_bundle: &CredentialBundle) {
-        let payload = &self.unsigned_payload().unwrap();
-        self.signature = credential_bundle.sign(payload).unwrap();
-    }
-}
-
-impl Signable for KeyPackage {
+    /// Compile the unsigned payload to create the signature required in the
+    /// signature field.
     fn unsigned_payload(&self) -> Result<Vec<u8>, CodecError> {
         let buffer = &mut Vec::new();
         self.protocol_version.encode(buffer)?;
@@ -216,6 +210,12 @@ impl Signable for KeyPackage {
             .collect();
         encode_vec(VecSize::VecU16, buffer, &encoded_extensions)?;
         Ok(buffer.to_vec())
+    }
+
+    /// Populate the `signature` field using the `credential_bundle`.
+    pub(crate) fn sign_self(&mut self, credential_bundle: &CredentialBundle) {
+        let payload = &self.unsigned_payload().unwrap();
+        self.signature = credential_bundle.sign(payload).unwrap();
     }
 }
 

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -65,7 +65,6 @@ impl KeyPackage {
         credential_bundle: &CredentialBundle,
         extensions: Vec<Box<dyn Extension>>,
     ) -> Self {
-        let ciphersuite = Ciphersuite::new(ciphersuite_name);
         let mut key_package = Self {
             // TODO: #85 Take from global config.
             protocol_version: ProtocolVersion::default(),
@@ -75,7 +74,7 @@ impl KeyPackage {
             extensions,
             signature: Signature::new_empty(),
         };
-        key_package.sign(&ciphersuite, credential_bundle.signature_private_key());
+        key_package.sign_self(&credential_bundle);
         key_package
     }
 
@@ -195,10 +194,10 @@ impl KeyPackage {
         &self.extensions
     }
 
-    /// Sign the key package.
-    pub(crate) fn sign(&mut self, ciphersuite: &Ciphersuite, signature_key: &SignaturePrivateKey) {
+    /// Populate the `signature` field using the `credential_bundle`.
+    pub(crate) fn sign_self(&mut self, credential_bundle: &CredentialBundle) {
         let payload = &self.unsigned_payload().unwrap();
-        self.signature = ciphersuite.sign(signature_key, payload).unwrap();
+        self.signature = credential_bundle.sign(payload).unwrap();
     }
 }
 

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -4,9 +4,8 @@ use crate::{extensions::*, key_packages::*};
 #[test]
 fn generate_key_package() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let id = vec![1, 2, 3];
     let credential_bundle =
-        CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap();
+        CredentialBundle::new(vec![1, 2, 3], CredentialType::Basic, ciphersuite_name).unwrap();
     let kpb = KeyPackageBundle::new(ciphersuite_name, &credential_bundle, Vec::new());
     // This is invalid because the lifetime extension is missing.
     assert!(!kpb.get_key_package().verify());
@@ -35,7 +34,6 @@ fn generate_key_package() {
 #[test]
 fn test_codec() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let id = vec![1, 2, 3];
     let credential_bundle =
         CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap();
@@ -51,7 +49,7 @@ fn test_codec() {
     // Add lifetime extension to make it valid.
     let kp = kpb.get_key_package_ref_mut();
     kp.add_extension(Box::new(LifetimeExtension::new(60)));
-    kp.sign(&ciphersuite, credential_bundle.signature_private_key());
+    kp.sign_self(&credential_bundle);
     let enc = kpb.get_key_package().encode_detached().unwrap();
 
     // Now it's valid.
@@ -62,7 +60,6 @@ fn test_codec() {
 #[test]
 fn key_package_id_extension() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let id = vec![1, 2, 3];
     let credential_bundle =
         CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap();
@@ -82,8 +79,7 @@ fn key_package_id_extension() {
     assert!(!kpb.get_key_package().verify());
 
     // Sign it to make it valid.
-    kpb.get_key_package_ref_mut()
-        .sign(&ciphersuite, credential_bundle.signature_private_key());
+    kpb.get_key_package_ref_mut().sign_self(&credential_bundle);
     assert!(kpb.get_key_package().verify());
 
     // Check ID

--- a/src/key_packages/test_key_packages.rs
+++ b/src/key_packages/test_key_packages.rs
@@ -49,7 +49,7 @@ fn test_codec() {
     // Add lifetime extension to make it valid.
     let kp = kpb.get_key_package_ref_mut();
     kp.add_extension(Box::new(LifetimeExtension::new(60)));
-    kp.sign_self(&credential_bundle);
+    kp.sign(&credential_bundle);
     let enc = kpb.get_key_package().encode_detached().unwrap();
 
     // Now it's valid.
@@ -79,7 +79,7 @@ fn key_package_id_extension() {
     assert!(!kpb.get_key_package().verify());
 
     // Sign it to make it valid.
-    kpb.get_key_package_ref_mut().sign_self(&credential_bundle);
+    kpb.get_key_package_ref_mut().sign(&credential_bundle);
     assert!(kpb.get_key_package().verify());
 
     // Check ID

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -427,7 +427,7 @@ impl RatchetTree {
         let parent_hash = self.compute_parent_hash(own_index);
         let key_package = self.get_own_key_package_ref_mut();
         key_package.update_parent_hash(&parent_hash);
-        key_package.sign_self(credential_bundle);
+        key_package.sign(credential_bundle);
 
         Ok((
             self.private_tree.get_commit_secret(),

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -401,7 +401,7 @@ impl RatchetTree {
     /// Update the private tree.
     pub(crate) fn refresh_private_tree(
         &mut self,
-        signature_key: &SignaturePrivateKey,
+        credential_bundle: &CredentialBundle,
         group_context: &[u8],
     ) -> Result<(CommitSecret, Option<UpdatePath>, Option<PathSecrets>), TreeError> {
         // Generate new keypair
@@ -425,11 +425,10 @@ impl RatchetTree {
         )?;
 
         // Compute the parent hash extension and update the KeyPackage
-        let csuite = self.ciphersuite.clone();
         let parent_hash = self.compute_parent_hash(own_index);
         let key_package = self.get_own_key_package_ref_mut();
         key_package.update_parent_hash(&parent_hash);
-        key_package.sign(&csuite, signature_key);
+        key_package.sign_self(credential_bundle);
 
         Ok((
             self.private_tree.get_commit_secret(),

--- a/src/tree/test_treemath.rs
+++ b/src/tree/test_treemath.rs
@@ -76,18 +76,10 @@ fn test_tree_hash() {
     use crate::tree::*;
 
     fn create_identity(id: &[u8], ciphersuite_name: CiphersuiteName) -> KeyPackageBundle {
-        let ciphersuite = Ciphersuite::new(ciphersuite_name);
-        let signature_keypair = ciphersuite.new_signature_keypair();
-        let identity = Identity::new(ciphersuite_name, id.to_vec());
-        let credential =
-            Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
-        let kbp = KeyPackageBundle::new(
-            ciphersuite_name,
-            signature_keypair.get_private_key(),
-            credential,
-            Vec::new(),
-        );
-        kbp
+        let credential_bundle =
+            CredentialBundle::new(id.to_vec(), CredentialType::Basic, ciphersuite_name).unwrap();
+        let kpb = KeyPackageBundle::new(ciphersuite_name, &credential_bundle, Vec::new());
+        kpb
     }
 
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -9,17 +9,10 @@ use maelstrom::key_packages::*;
 #[test]
 fn padding() {
     let ciphersuite_name = CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519;
-    let ciphersuite = Ciphersuite::new(ciphersuite_name);
     let id = vec![1, 2, 3];
-    let identity = Identity::new(ciphersuite_name, vec![1, 2, 3]);
-    let signature_keypair = ciphersuite.new_signature_keypair();
-    let credential = Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
-    let kpb = KeyPackageBundle::new(
-        ciphersuite_name,
-        signature_keypair.get_private_key(),
-        credential,
-        Vec::new(),
-    );
+    let credential_bundle =
+        CredentialBundle::new(id.clone(), CredentialType::Basic, ciphersuite_name).unwrap();
+    let kpb = KeyPackageBundle::new(ciphersuite_name, &credential_bundle, Vec::new());
 
     let mut group_alice = MlsGroup::new(&id, ciphersuite_name, kpb);
     const PADDING_SIZE: usize = 10;
@@ -28,7 +21,7 @@ fn padding() {
         let message = randombytes(random_usize() % 1000);
         let aad = randombytes(random_usize() % 1000);
         let encrypted_message = group_alice
-            .create_application_message(&aad, &message, signature_keypair.get_private_key())
+            .create_application_message(&aad, &message, credential_bundle.signature_private_key())
             .as_slice();
         let length = encrypted_message.len();
         let overflow = length % PADDING_SIZE;

--- a/tests/test_framing.rs
+++ b/tests/test_framing.rs
@@ -21,7 +21,7 @@ fn padding() {
         let message = randombytes(random_usize() % 1000);
         let aad = randombytes(random_usize() % 1000);
         let encrypted_message = group_alice
-            .create_application_message(&aad, &message, credential_bundle.signature_private_key())
+            .create_application_message(&aad, &message, &credential_bundle)
             .as_slice();
         let length = encrypted_message.len();
         let overflow = length % PADDING_SIZE;

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -10,33 +10,28 @@ fn create_commit_optional_path() {
     let group_aad = b"Alice's test group";
 
     // Define identities
-    let alice_identity = Identity::new(ciphersuite_name, "Alice".into());
-    let bob_identity = Identity::new(ciphersuite_name, "Bob".into());
-
-    // Define credentials
-    let alice_credential = BasicCredential::from(&alice_identity);
-    let bob_credential = BasicCredential::from(&bob_identity);
+    let alice_credential_bundle =
+        CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite_name).unwrap();
+    let bob_credential_bundle =
+        CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite_name).unwrap();
 
     // Generate KeyPackages
     let alice_key_package_bundle = KeyPackageBundle::new(
         ciphersuite_name,
-        &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::from(MLSCredentialType::Basic(alice_credential.clone())), // TODO: this consumes the credential!
+        &alice_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Vec::new(),
     );
 
     let bob_key_package_bundle = KeyPackageBundle::new(
         ciphersuite_name,
-        &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::from(MLSCredentialType::Basic(bob_credential)), // TODO: this consumes the credential!
+        &bob_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Vec::new(),
     );
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
     let alice_update_key_package_bundle = KeyPackageBundle::new(
         ciphersuite_name,
-        &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::from(MLSCredentialType::Basic(alice_credential)),
+        &alice_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Vec::new(),
     );
     let alice_update_key_package = alice_update_key_package_bundle.get_key_package();
@@ -48,21 +43,21 @@ fn create_commit_optional_path() {
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
         group_aad,
-        &alice_identity.get_signature_key_pair().get_private_key(),
+        &alice_credential_bundle.signature_private_key(),
         bob_key_package.clone(),
     );
 
     // Alice updates
     let alice_update_proposal = group_alice_1234.create_update_proposal(
         group_aad,
-        &alice_identity.get_signature_key_pair().get_private_key(),
+        &alice_credential_bundle.signature_private_key(),
         alice_update_key_package.clone(),
     );
 
     // Only AddProposals
     let (commit_mls_plaintext, _welcome_option) = match group_alice_1234.create_commit(
         group_aad,
-        &alice_identity.get_signature_key_pair().get_private_key(),
+        &alice_credential_bundle.signature_private_key(),
         vec![bob_add_proposal.clone()],
         false,
     ) {
@@ -78,7 +73,7 @@ fn create_commit_optional_path() {
     // Only AddProposals with forced self update
     let (commit_mls_plaintext, _welcome_option) = match group_alice_1234.create_commit(
         group_aad,
-        &alice_identity.get_signature_key_pair().get_private_key(),
+        &alice_credential_bundle.signature_private_key(),
         vec![bob_add_proposal],
         true,
     ) {
@@ -95,7 +90,7 @@ fn create_commit_optional_path() {
     // Own UpdateProposal
     let (commit_mls_plaintext, _welcome_option) = match group_alice_1234.create_commit(
         group_aad,
-        &alice_identity.get_signature_key_pair().get_private_key(),
+        &alice_credential_bundle.signature_private_key(),
         vec![alice_update_proposal],
         true,
     ) {
@@ -115,26 +110,22 @@ fn basic_group_setup() {
     let group_aad = b"Alice's test group";
 
     // Define identities
-    let alice_identity = Identity::new(ciphersuite_name, "Alice".into());
-    let bob_identity = Identity::new(ciphersuite_name, "Bob".into());
-
-    // Define credentials
-    let alice_credential = BasicCredential::from(&alice_identity);
-    let bob_credential = BasicCredential::from(&bob_identity);
+    let alice_credential_bundle =
+        CredentialBundle::new("Alice".into(), CredentialType::Basic, ciphersuite_name).unwrap();
+    let bob_credential_bundle =
+        CredentialBundle::new("Bob".into(), CredentialType::Basic, ciphersuite_name).unwrap();
 
     // Generate KeyPackages
     let bob_key_package_bundle = KeyPackageBundle::new(
         ciphersuite_name,
-        &bob_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::from(MLSCredentialType::Basic(bob_credential)), // TODO: this consumes the credential!
+        &bob_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Vec::new(),
     );
     let bob_key_package = bob_key_package_bundle.get_key_package();
 
     let alice_key_package_bundle = KeyPackageBundle::new(
         ciphersuite_name,
-        &alice_identity.get_signature_key_pair().get_private_key(), // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
-        Credential::from(MLSCredentialType::Basic(alice_credential)),
+        &alice_credential_bundle, // TODO: bad API, we shouldn't have to get the private key out here (this function shouldn't exist!)
         Vec::new(),
     );
 
@@ -145,12 +136,12 @@ fn basic_group_setup() {
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
         group_aad,
-        &alice_identity.get_signature_key_pair().get_private_key(),
+        &alice_credential_bundle.signature_private_key(),
         bob_key_package.clone(),
     );
     let _commit = match group_alice_1234.create_commit(
         group_aad,
-        &alice_identity.get_signature_key_pair().get_private_key(),
+        &alice_credential_bundle.signature_private_key(),
         vec![bob_add_proposal],
         true,
     ) {

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -43,21 +43,21 @@ fn create_commit_optional_path() {
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
         group_aad,
-        &alice_credential_bundle.signature_private_key(),
+        &bob_credential_bundle,
         bob_key_package.clone(),
     );
 
     // Alice updates
     let alice_update_proposal = group_alice_1234.create_update_proposal(
         group_aad,
-        &alice_credential_bundle.signature_private_key(),
+        &alice_credential_bundle,
         alice_update_key_package.clone(),
     );
 
     // Only AddProposals
     let (commit_mls_plaintext, _welcome_option) = match group_alice_1234.create_commit(
         group_aad,
-        &alice_credential_bundle.signature_private_key(),
+        &alice_credential_bundle,
         vec![bob_add_proposal.clone()],
         false,
     ) {
@@ -73,7 +73,7 @@ fn create_commit_optional_path() {
     // Only AddProposals with forced self update
     let (commit_mls_plaintext, _welcome_option) = match group_alice_1234.create_commit(
         group_aad,
-        &alice_credential_bundle.signature_private_key(),
+        &alice_credential_bundle,
         vec![bob_add_proposal],
         true,
     ) {
@@ -90,7 +90,7 @@ fn create_commit_optional_path() {
     // Own UpdateProposal
     let (commit_mls_plaintext, _welcome_option) = match group_alice_1234.create_commit(
         group_aad,
-        &alice_credential_bundle.signature_private_key(),
+        &alice_credential_bundle,
         vec![alice_update_proposal],
         true,
     ) {
@@ -136,12 +136,12 @@ fn basic_group_setup() {
     // Alice adds Bob
     let bob_add_proposal = group_alice_1234.create_add_proposal(
         group_aad,
-        &alice_credential_bundle.signature_private_key(),
+        &alice_credential_bundle,
         bob_key_package.clone(),
     );
     let _commit = match group_alice_1234.create_commit(
         group_aad,
-        &alice_credential_bundle.signature_private_key(),
+        &alice_credential_bundle,
         vec![bob_add_proposal],
         true,
     ) {

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -20,17 +20,10 @@ macro_rules! key_package_generation {
             let ciphersuite = Ciphersuite::new($ciphersuite);
             let supported_ciphersuites = Config::supported_ciphersuites();
             assert_eq!($supported, supported_ciphersuites.contains(&$ciphersuite));
-            let signature_keypair = ciphersuite.new_signature_keypair();
-            let identity =
-                Identity::new_with_keypair(ciphersuite, vec![1, 2, 3], signature_keypair.clone());
-            let credential =
-                Credential::from(MLSCredentialType::Basic(BasicCredential::from(&identity)));
-            let kpb = KeyPackageBundle::new(
-                $ciphersuite,
-                signature_keypair.get_private_key(),
-                credential,
-                Vec::new(),
-            );
+            let id = vec![1, 2, 3];
+            let credential_bundle =
+                CredentialBundle::new(id, CredentialType::Basic, ciphersuite.get_name()).unwrap();
+            let kpb = KeyPackageBundle::new(ciphersuite.get_name(), &credential_bundle, Vec::new());
 
             let extensions = kpb.get_key_package().get_extensions_ref();
 


### PR DESCRIPTION
This PR cleans up the API a little by getting rid of Identity and introducing `CredentialBundle`, which, analogous to `KeyPackageBundle`, contains a `Credential` and the corresponding `PrivateSignatureKey`.