### PR TITLE
Some leaf index refactoring

### DIFF
--- a/src/group/managed_group.rs
+++ b/src/group/managed_group.rs
@@ -21,7 +21,7 @@ use crate::framing::*;
 use crate::group::*;
 use crate::key_packages::*;
 use crate::messages::{proposals::*, *};
-use crate::tree::{index::*, node::*};
+use crate::tree::node::*;
 
 pub struct ManagedGroup {
     pub group: MlsGroup,
@@ -76,7 +76,7 @@ impl ManagedGroup {
     pub fn get_members(&self) -> Vec<Credential> {
         let mut members = Vec::new();
         for i in 0..self.group.get_tree().leaf_count().as_usize() {
-            let node = self.group.get_tree().nodes[NodeIndex::from(i).as_usize()].clone();
+            let node = self.group.get_tree().nodes[i].clone();
             let credential = node.key_package.unwrap().get_credential().clone();
             members.push(credential);
         }

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -224,7 +224,7 @@ impl Api for MlsGroup {
         let tree = self.tree.borrow();
         let mut roster = Vec::new();
         for i in 0..tree.leaf_count().as_usize() {
-            let node = &tree.nodes[NodeIndex::from(i).as_usize()];
+            let node = &tree.nodes[i];
             let credential = if let Some(kp) = &node.key_package {
                 kp.get_credential()
             } else {

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -75,7 +75,7 @@ impl MlsGroup {
         }
 
         // Verify GroupInfo signature
-        let signer_node = tree.nodes[NodeIndex::from(group_info.signer_index).as_usize()].clone();
+        let signer_node = tree.nodes[group_info.signer_index].clone();
         let signer_key_package = signer_node.key_package.unwrap();
         let payload = group_info.unsigned_payload().unwrap();
         if !signer_key_package

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -80,6 +80,10 @@ impl From<NodeIndex> for LeafIndex {
 impl Index<LeafIndex> for Vec<Node> {
     type Output = Node;
 
+    /// This converts a `LeafIndex`, which points to a particular leaf in the
+    /// vector of leaves in a tree, to a `NodeIndex`, i.e. it makes it point the
+    /// same leaf, but in the array representing the tree as opposed to the one
+    /// only containing the leaves.
     fn index(&self, leaf_index: LeafIndex) -> &Self::Output {
         &self[leaf_index.as_usize() * 2]
     }

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -1,4 +1,8 @@
+use std::ops::Index;
+
 use crate::codec::*;
+
+use super::node::Node;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone, Hash, Default)]
 pub struct NodeIndex(u32);
@@ -69,6 +73,14 @@ impl From<usize> for LeafIndex {
 impl From<NodeIndex> for LeafIndex {
     fn from(tree_index: NodeIndex) -> LeafIndex {
         LeafIndex((tree_index.as_u32() + 1) / 2)
+    }
+}
+
+impl Index<LeafIndex> for Vec<Node> {
+    type Output = Node;
+
+    fn index(&self, leaf_index: LeafIndex) -> &Self::Output {
+        &self[leaf_index.as_usize() * 2]
     }
 }
 

--- a/src/tree/index.rs
+++ b/src/tree/index.rs
@@ -1,4 +1,5 @@
 use std::ops::Index;
+use std::ops::IndexMut;
 
 use crate::codec::*;
 
@@ -81,6 +82,12 @@ impl Index<LeafIndex> for Vec<Node> {
 
     fn index(&self, leaf_index: LeafIndex) -> &Self::Output {
         &self[leaf_index.as_usize() * 2]
+    }
+}
+
+impl IndexMut<LeafIndex> for Vec<Node> {
+    fn index_mut(&mut self, leaf_index: LeafIndex) -> &mut Self::Output {
+        &mut self[leaf_index.as_usize() * 2]
     }
 }
 

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -254,7 +254,7 @@ impl RatchetTree {
         for i in 0..self.leaf_count().as_usize() {
             // TODO use an iterator instead
             let leaf_index = LeafIndex::from(i);
-            if self.nodes[NodeIndex::from(leaf_index).as_usize()].is_blank() {
+            if self.nodes[leaf_index].is_blank() {
                 free_leaves.push(NodeIndex::from(i));
             }
         }
@@ -376,8 +376,7 @@ impl RatchetTree {
         // Merge new nodes into the tree
         self.merge_direct_path_keys(update_path, sender_direct_path)?;
         self.merge_public_keys(&new_path_public_keys, &common_path)?;
-        self.nodes[NodeIndex::from(sender).as_usize()] =
-            Node::new_leaf(Some(update_path.leaf_key_package.clone()));
+        self.nodes[sender] = Node::new_leaf(Some(update_path.leaf_key_package.clone()));
         self.compute_parent_hash(NodeIndex::from(sender));
 
         // TODO: Do we really want to return the commit secret here?


### PR DESCRIPTION
This PR aims to reduce some of the conversions from `LeafIndex` to `NodeIndex` by implementing `Index` and `MutIndex`, so we can index `Vec<Node>` directly with `LeafIndex` without an explicit detour via `NodeIndex`