### PR TITLE
bump hpke and evercrypt version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,16 @@ byteorder = "^1.3"
 lazy_static = "1.4"
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "^1.0"
-hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", version = "0.0.2-dev2"}
-evercrypt = { version = "0.0.3-dev3" }
+hpke = {git = "https://github.com/franziskuskiefer/hpke-rs", version = "0.0.2", branch = "0.0.2", features = ["hazmat", "serialization"] }
+evercrypt = { version = "0.0.3" }
 
 [features]
 default = ["rust-crypto"]
 rust-crypto = ["evercrypt/rust-crypto-aes"]
 
 [patch.crates-io]
-evercrypt = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt" }
-evercrypt-sys = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt-sys" }
+evercrypt = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt", branch = "0.0.3" }
+evercrypt-sys = { git = "https://github.com/franziskuskiefer/evercrypt-rust", package = "evercrypt-sys", branch = "0.0.3" }
 
 [dev-dependencies]
 criterion = "^0.2"

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -33,6 +33,9 @@ mod codec;
 pub(crate) mod signable;
 use ciphersuites::*;
 
+#[cfg(test)]
+mod test_ciphersuite;
+
 pub const NONCE_BYTES: usize = 12;
 pub const CHACHA_KEY_BYTES: usize = 32;
 pub const AES_128_KEY_BYTES: usize = 16;

--- a/src/ciphersuite/test_ciphersuite.rs
+++ b/src/ciphersuite/test_ciphersuite.rs
@@ -1,0 +1,17 @@
+//! Unit tests for the ciphersuites.
+
+use super::*;
+use crate::config::Config;
+
+// Spot test to make sure hpke seal works.
+#[test]
+fn test_hpke_seal() {
+    // Test through ciphersuites.
+    for &suite in Config::supported_ciphersuites() {
+        println!("Test {:?}", suite);
+        let ciphersuite = Ciphersuite::new(suite);
+        println!("Ciphersuite {:?}", ciphersuite);
+        let kp = ciphersuite.new_hpke_keypair();
+        ciphersuite.hpke_seal(kp.get_public_key_ref(), &[], &[], &[1, 2, 3]);
+    }
+}

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -255,7 +255,7 @@ impl KeyPackageBundle {
         let mut final_extensions: Vec<Box<dyn Extension>> =
             vec![Box::new(CapabilitiesExtension::default())];
 
-        let (private_key, public_key) = key_pair.to_keys();
+        let (private_key, public_key) = key_pair.into_keys();
         final_extensions.extend_from_slice(&extensions);
         let key_package = KeyPackage::new(
             ciphersuite_name,

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -405,7 +405,7 @@ impl RatchetTree {
     ) -> Result<(CommitSecret, Option<UpdatePath>, Option<PathSecrets>), TreeError> {
         // Generate new keypair
         let own_index = self.get_own_node_index();
-        let (private_key, public_key) = self.ciphersuite.new_hpke_keypair().to_keys();
+        let (private_key, public_key) = self.ciphersuite.new_hpke_keypair().into_keys();
 
         // Replace the init key in the current KeyPackage
         let key_package_bundle = {

--- a/src/tree/private_tree.rs
+++ b/src/tree/private_tree.rs
@@ -205,7 +205,7 @@ impl PrivateTree {
         for path_secret in self.path_secrets.iter() {
             let node_secret = hkdf_expand_label(ciphersuite, &path_secret, "node", &[], hash_len);
             let keypair = ciphersuite.derive_hpke_keypair(&node_secret);
-            let (private_key, public_key) = keypair.to_keys();
+            let (private_key, public_key) = keypair.into_keys();
             public_keys.push(public_key);
             private_keys.push(private_key);
         }


### PR DESCRIPTION
HPKE 0.0.2 is almost there. Moving to the new version here already to unblock #129 .

* also adds a basic hpke seal test, there should be more of this
* The `as_slice` function of `HPKEPrivateKey` is behind the `hazmat` feature. We should try to get rid of this.