### PR TITLE
ciphersuites cleanup: Signature keys

### DIFF
--- a/src/ciphersuite/codec.rs
+++ b/src/ciphersuite/codec.rs
@@ -42,44 +42,10 @@ impl Codec for Ciphersuite {
     }
 }
 
-impl Codec for SignatureKeypair {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        self.ciphersuite.encode(buffer)?;
-        self.private_key.encode(buffer)?;
-        self.public_key.encode(buffer)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let ciphersuite = Ciphersuite::decode(cursor)?;
-        let private_key = SignaturePrivateKey::decode(cursor)?;
-        let public_key = SignaturePublicKey::decode(cursor)?;
-        Ok(Self {
-            ciphersuite,
-            private_key,
-            public_key,
-        })
-    }
-}
-
 impl Codec for SignaturePublicKey {
     fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
         encode_vec(VecSize::VecU16, buffer, &self.value)?;
         Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let value = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(Self { value })
-    }
-}
-
-impl Codec for SignaturePrivateKey {
-    fn encode(&self, buffer: &mut Vec<u8>) -> Result<(), CodecError> {
-        encode_vec(VecSize::VecU16, buffer, &self.value)?;
-        Ok(())
-    }
-    fn decode(cursor: &mut Cursor) -> Result<Self, CodecError> {
-        let value = decode_vec(VecSize::VecU16, cursor)?;
-        Ok(Self { value })
     }
 }
 

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -98,11 +98,13 @@ pub struct Signature {
 
 #[derive(Clone)]
 pub struct SignaturePrivateKey {
+    ciphersuite: Ciphersuite,
     value: Vec<u8>,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub struct SignaturePublicKey {
+    ciphersuite: Ciphersuite,
     value: Vec<u8>,
 }
 
@@ -159,27 +161,6 @@ impl Ciphersuite {
         self.name
     }
 
-    /// Sign a `msg` with the given `sk`.
-    pub(crate) fn sign(
-        &self,
-        sk: &SignaturePrivateKey,
-        msg: &[u8],
-    ) -> Result<Signature, SignatureError> {
-        let (hash, nonce) = match self.signature {
-            SignatureMode::Ed25519 => (None, None),
-            SignatureMode::P256 => (Some(self.hash), Some(p256_ecdsa_random_nonce())),
-        };
-        match sign(self.signature, hash, &sk.value, msg, nonce.as_ref()) {
-            Ok(s) => Ok(Signature { value: s }),
-            Err(e) => Err(e),
-        }
-    }
-
-    /// Verify a `msg` against `sig` and `pk`.
-    pub(crate) fn verify(&self, sig: &Signature, pk: &SignaturePublicKey, msg: &[u8]) -> bool {
-        verify(self.signature, Some(self.hash), &pk.value, &sig.value, msg).unwrap()
-    }
-
     /// Create a new signature key pair and return it.
     pub fn new_signature_keypair(&self) -> SignatureKeypair {
         let (sk, pk) = match signature_key_gen(self.signature) {
@@ -188,8 +169,14 @@ impl Ciphersuite {
         };
         SignatureKeypair {
             ciphersuite: self.clone(),
-            private_key: SignaturePrivateKey { value: sk.to_vec() },
-            public_key: SignaturePublicKey { value: pk.to_vec() },
+            private_key: SignaturePrivateKey {
+                value: sk.to_vec(),
+                ciphersuite: self.clone(),
+            },
+            public_key: SignaturePublicKey {
+                value: pk.to_vec(),
+                ciphersuite: self.clone(),
+            },
         }
     }
 
@@ -358,24 +345,19 @@ impl Signature {
     pub(crate) fn new_empty() -> Signature {
         Signature { value: vec![] }
     }
-    pub(crate) fn as_slice(&self) -> &[u8] {
-        &self.value
-    }
 }
 
 impl SignatureKeypair {
+    /// Sign the `payload` byte slice with this signature key.
+    /// Returns a `Result` with a `Signature` or a `SignatureError`.
     pub fn sign(&self, payload: &[u8]) -> Result<Signature, SignatureError> {
-        self.ciphersuite.sign(&self.private_key, payload)
+        self.private_key.sign(&payload)
     }
 
-    /// Get a reference to the private key.
-    pub fn get_private_key(&self) -> &SignaturePrivateKey {
-        &self.private_key
-    }
-
-    /// Get a reference to the public key.
-    pub fn get_public_key(&self) -> &SignaturePublicKey {
-        &self.public_key
+    /// Verify a `Signature` on the `payload` byte slice with the key pair's
+    /// public key.
+    pub fn verify(&self, signature: &Signature, payload: &[u8]) -> bool {
+        self.public_key.verify(signature, payload)
     }
 
     /// Get the private and public key objects
@@ -384,14 +366,51 @@ impl SignatureKeypair {
     }
 }
 
-#[test]
-fn test_sign_verify() {
-    let ciphersuite =
-        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
-    let keypair = ciphersuite.new_signature_keypair();
-    let payload = &[1, 2, 3];
-    let signature = ciphersuite
-        .sign(keypair.get_private_key(), payload)
-        .unwrap();
-    assert!(ciphersuite.verify(&signature, keypair.get_public_key(), payload));
+impl PartialEq for SignaturePublicKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl SignaturePublicKey {
+    /// Create a new signature public key from raw key bytes.
+    pub fn new(bytes: Vec<u8>, ciphersuite: Ciphersuite) -> Self {
+        Self {
+            value: bytes,
+            ciphersuite,
+        }
+    }
+    /// Verify a `Signature` on the `payload` byte slice with the key pair's
+    /// public key.
+    pub fn verify(&self, signature: &Signature, payload: &[u8]) -> bool {
+        verify(
+            self.ciphersuite.signature,
+            Some(self.ciphersuite.hash),
+            &self.value,
+            &signature.value,
+            payload,
+        )
+        .unwrap()
+    }
+}
+
+impl SignaturePrivateKey {
+    /// Sign the `payload` byte slice with this signature key.
+    /// Returns a `Result` with a `Signature` or a `SignatureError`.
+    pub fn sign(&self, payload: &[u8]) -> Result<Signature, SignatureError> {
+        let (hash, nonce) = match self.ciphersuite.signature {
+            SignatureMode::Ed25519 => (None, None),
+            SignatureMode::P256 => (Some(self.ciphersuite.hash), Some(p256_ecdsa_random_nonce())),
+        };
+        match sign(
+            self.ciphersuite.signature,
+            hash,
+            &self.value,
+            payload,
+            nonce.as_ref(),
+        ) {
+            Ok(s) => Ok(Signature { value: s }),
+            Err(e) => Err(e),
+        }
+    }
 }

--- a/src/ciphersuite/mod.rs
+++ b/src/ciphersuite/mod.rs
@@ -155,7 +155,7 @@ impl Ciphersuite {
     }
 
     /// Get the name of this ciphersuite.
-    pub fn get_name(&self) -> CiphersuiteName {
+    pub fn name(&self) -> CiphersuiteName {
         self.name
     }
 

--- a/src/ciphersuite/test_ciphersuite.rs
+++ b/src/ciphersuite/test_ciphersuite.rs
@@ -15,3 +15,13 @@ fn test_hpke_seal() {
         ciphersuite.hpke_seal(kp.get_public_key_ref(), &[], &[], &[1, 2, 3]);
     }
 }
+
+#[test]
+fn test_sign_verify() {
+    let ciphersuite =
+        Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
+    let keypair = ciphersuite.new_signature_keypair();
+    let payload = &[1, 2, 3];
+    let signature = keypair.sign(payload).unwrap();
+    assert!(keypair.verify(&signature, payload));
+}

--- a/src/framing/test_framing.rs
+++ b/src/framing/test_framing.rs
@@ -24,8 +24,7 @@ fn codec() {
     let ciphersuite =
         Ciphersuite::new(CiphersuiteName::MLS10_128_DHKEMX25519_AES128GCM_SHA256_Ed25519);
     let credential_bundle =
-        CredentialBundle::new(vec![7, 8, 9], CredentialType::Basic, ciphersuite.get_name())
-            .unwrap();
+        CredentialBundle::new(vec![7, 8, 9], CredentialType::Basic, ciphersuite.name()).unwrap();
     let sender = Sender {
         sender_type: SenderType::Member,
         sender: LeafIndex::from(2u32),

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -192,7 +192,7 @@ impl MlsGroup {
             // Create welcome message
             let welcome = Welcome::new(
                 Config::supported_versions()[0],
-                self.ciphersuite.get_name(),
+                self.ciphersuite.name(),
                 secrets,
                 encrypted_group_info,
             );

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -22,8 +22,8 @@ macro_rules! key_package_generation {
             assert_eq!($supported, supported_ciphersuites.contains(&$ciphersuite));
             let id = vec![1, 2, 3];
             let credential_bundle =
-                CredentialBundle::new(id, CredentialType::Basic, ciphersuite.get_name()).unwrap();
-            let kpb = KeyPackageBundle::new(ciphersuite.get_name(), &credential_bundle, Vec::new());
+                CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name()).unwrap();
+            let kpb = KeyPackageBundle::new(ciphersuite.name(), &credential_bundle, Vec::new());
 
             let extensions = kpb.get_key_package().get_extensions_ref();
 


### PR DESCRIPTION
Move sign and verify into the signature keys.

Note that this requires cloning the ciphersuite into the keys for now. This should be changed later by using a global ciphersuite from the config or borrowing the existing cihpersuite.

