### PR TITLE
misc cleanup naming

### DIFF
--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -221,7 +221,7 @@ pub trait Extension: Debug + ExtensionHelper {
     /// Get a reference to the `ParentHashExtension`.
     /// Returns an `InvalidExtensionType` error if called on an `Extension`
     /// that's not a `ParentHashExtension`.
-    fn to_parent_hash_extension_ref(&self) -> Result<&ParentHashExtension, ExtensionError> {
+    fn to_parent_hash_extension(&self) -> Result<&ParentHashExtension, ExtensionError> {
         match self.as_any().downcast_ref::<ParentHashExtension>() {
             Some(e) => Ok(e),
             None => Err(ExtensionError::InvalidExtensionType),
@@ -231,7 +231,7 @@ pub trait Extension: Debug + ExtensionHelper {
     /// Get a reference to the `CapabilitiesExtension`.
     /// Returns an `InvalidExtensionType` error if called on an `Extension`
     /// that's not a `CapabilitiesExtension`.
-    fn to_capabilities_extension_ref(&self) -> Result<&CapabilitiesExtension, ExtensionError> {
+    fn to_capabilities_extension(&self) -> Result<&CapabilitiesExtension, ExtensionError> {
         match self.as_any().downcast_ref::<CapabilitiesExtension>() {
             Some(e) => Ok(e),
             None => Err(ExtensionError::InvalidExtensionType),
@@ -241,7 +241,7 @@ pub trait Extension: Debug + ExtensionHelper {
     /// Get a reference to the `LifetimeExtension`.
     /// Returns an `InvalidExtensionType` error if called on an `Extension`
     /// that's not a `LifetimeExtension`.
-    fn to_lifetime_extension_ref(&self) -> Result<&LifetimeExtension, ExtensionError> {
+    fn to_lifetime_extension(&self) -> Result<&LifetimeExtension, ExtensionError> {
         match self.as_any().downcast_ref::<LifetimeExtension>() {
             Some(e) => Ok(e),
             None => Err(ExtensionError::InvalidExtensionType),
@@ -251,7 +251,7 @@ pub trait Extension: Debug + ExtensionHelper {
     /// Get a reference to the `KeyIDExtension`.
     /// Returns an `InvalidExtensionType` error if called on an `Extension`
     /// that's not a `KeyIDExtension`.
-    fn to_key_id_extension_ref(&self) -> Result<&KeyIDExtension, ExtensionError> {
+    fn to_key_id_extension(&self) -> Result<&KeyIDExtension, ExtensionError> {
         match self.as_any().downcast_ref::<KeyIDExtension>() {
             Some(e) => Ok(e),
             None => Err(ExtensionError::InvalidExtensionType),

--- a/src/extensions/parent_hash_extension.rs
+++ b/src/extensions/parent_hash_extension.rs
@@ -35,7 +35,7 @@ impl ParentHashExtension {
     }
 
     /// Get a reference to the parent hash value.
-    pub(crate) fn get_parent_hash_ref(&self) -> &[u8] {
+    pub(crate) fn parent_hash(&self) -> &[u8] {
         &self.parent_hash
     }
 }

--- a/src/group/managed_group.rs
+++ b/src/group/managed_group.rs
@@ -77,7 +77,7 @@ impl ManagedGroup {
         let mut members = Vec::new();
         for i in 0..self.group.tree().leaf_count().as_usize() {
             let node = self.group.tree().nodes[i].clone();
-            let credential = node.key_package.unwrap().get_credential().clone();
+            let credential = node.key_package.unwrap().credential().clone();
             members.push(credential);
         }
         members

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -158,8 +158,8 @@ impl MlsGroup {
                     .get_extension(ExtensionType::ParentHash)
                 {
                     let parent_hash_extension =
-                        received_parent_hash.to_parent_hash_extension_ref()?;
-                    if parent_hash != parent_hash_extension.get_parent_hash_ref() {
+                        received_parent_hash.to_parent_hash_extension()?;
+                    if parent_hash != parent_hash_extension.parent_hash() {
                         return Err(ApplyCommitError::ParentHashMismatch);
                     }
                 } else {

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -157,8 +157,7 @@ impl MlsGroup {
                     .leaf_key_package
                     .get_extension(ExtensionType::ParentHash)
                 {
-                    let parent_hash_extension =
-                        received_parent_hash.to_parent_hash_extension()?;
+                    let parent_hash_extension = received_parent_hash.to_parent_hash_extension()?;
                     if parent_hash != parent_hash_extension.parent_hash() {
                         return Err(ApplyCommitError::ParentHashMismatch);
                     }

--- a/src/group/mls_group/apply_commit.rs
+++ b/src/group/mls_group/apply_commit.rs
@@ -80,7 +80,7 @@ impl MlsGroup {
                 return Err(ApplyCommitError::PathKeyPackageVerificationFailure);
             }
             let serialized_context = self.group_context.encode_detached().unwrap();
-            if !mls_plaintext.verify(Some(serialized_context.clone()), kp.get_credential()) {
+            if !mls_plaintext.verify(Some(serialized_context.clone()), kp.credential()) {
                 return Err(ApplyCommitError::PlaintextSignatureFailure);
             }
             if is_own_commit {

--- a/src/group/mls_group/create_commit.rs
+++ b/src/group/mls_group/create_commit.rs
@@ -171,7 +171,7 @@ impl MlsGroup {
                 };
                 let group_secrets_bytes = group_secrets.encode_detached().unwrap();
                 plaintext_secrets.push((
-                    key_package.get_hpke_init_key().clone(),
+                    key_package.hpke_init_key().clone(),
                     group_secrets_bytes,
                     key_package_hash,
                 ));

--- a/src/group/mls_group/mod.rs
+++ b/src/group/mls_group/mod.rs
@@ -229,7 +229,7 @@ impl Api for MlsGroup {
         for i in 0..tree.leaf_count().as_usize() {
             let node = &tree.nodes[LeafIndex::from(i)];
             let credential = if let Some(kp) = &node.key_package {
-                kp.get_credential()
+                kp.credential()
             } else {
                 panic!("Missing key package");
             };

--- a/src/group/mls_group/new_from_welcome.rs
+++ b/src/group/mls_group/new_from_welcome.rs
@@ -43,7 +43,7 @@ impl MlsGroup {
         } else {
             return Err(WelcomeError::JoinerSecretNotFound);
         };
-        if ciphersuite_name != key_package.get_cipher_suite() {
+        if ciphersuite_name != key_package.cipher_suite() {
             return Err(WelcomeError::CiphersuiteMismatch);
         }
 
@@ -79,7 +79,7 @@ impl MlsGroup {
         let signer_key_package = signer_node.key_package.unwrap();
         let payload = group_info.unsigned_payload().unwrap();
         if !signer_key_package
-            .get_credential()
+            .credential()
             .verify(&payload, &group_info.signature)
         {
             return Err(WelcomeError::InvalidGroupInfoSignature);
@@ -102,7 +102,7 @@ impl MlsGroup {
                 .expect("new_from_welcome_internal: TreeMath error when computing direct path.");
 
             // Update the private tree.
-            let private_tree = tree.get_private_tree_mut();
+            let private_tree = tree.private_tree_mut();
             private_tree.generate_path_secrets(
                 &ciphersuite,
                 Some(&path_secret.path_secret),

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -99,7 +99,7 @@ impl KeyPackage {
             }
             // Make sure the lifetime is valid.
             if extension.get_type() == ExtensionType::Lifetime {
-                match extension.to_lifetime_extension_ref() {
+                match extension.to_lifetime_extension() {
                     Ok(e) => {
                         if !e.is_valid() {
                             return Err(KeyPackageError::InvalidLifetimeExtension);
@@ -154,7 +154,7 @@ impl KeyPackage {
     /// Returns an error if no Key ID extension is present.
     pub fn get_id(&self) -> Result<&[u8], KeyPackageError> {
         if let Some(key_id_ext) = self.get_extension(ExtensionType::KeyID) {
-            return Ok(key_id_ext.to_key_id_extension_ref()?.as_slice());
+            return Ok(key_id_ext.to_key_id_extension()?.as_slice());
         }
         Err(KeyPackageError::ExtensionNotPresent)
     }

--- a/src/key_packages/mod.rs
+++ b/src/key_packages/mod.rs
@@ -182,12 +182,12 @@ impl KeyPackage {
     }
 
     /// Get a reference to the credential.
-    pub(crate) fn get_credential(&self) -> &Credential {
+    pub(crate) fn credential(&self) -> &Credential {
         &self.credential
     }
 
     /// Get a reference to the HPKE init key.
-    pub(crate) fn get_hpke_init_key(&self) -> &HPKEPublicKey {
+    pub(crate) fn hpke_init_key(&self) -> &HPKEPublicKey {
         &self.hpke_init_key
     }
 
@@ -196,13 +196,13 @@ impl KeyPackage {
         self.hpke_init_key = hpke_init_key;
     }
 
-    /// Get a reference to the `Ciphersuite`.
-    pub(crate) fn get_cipher_suite(&self) -> CiphersuiteName {
+    /// Get the `CiphersuiteName`.
+    pub(crate) fn cipher_suite(&self) -> CiphersuiteName {
         self.cipher_suite
     }
 
     /// Get a reference to the extensions of this key package.
-    pub fn get_extensions_ref(&self) -> &[Box<dyn Extension>] {
+    pub fn extensions(&self) -> &[Box<dyn Extension>] {
         &self.extensions
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,6 @@ pub mod group;
 pub mod key_packages;
 pub mod messages;
 pub mod schedule;
-mod tree;
+pub mod tree;
 pub mod utils;
 pub mod validator;

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -24,7 +24,7 @@ use crate::messages::{proposals::*, *};
 pub(crate) mod codec;
 pub(crate) mod hash_input;
 pub(crate) mod index;
-pub(crate) mod node;
+pub mod node;
 pub(crate) mod path_keys;
 pub(crate) mod private_tree;
 pub(crate) mod secret_tree;
@@ -140,7 +140,7 @@ impl RatchetTree {
     }
 
     /// Return a mutable reference to the `PrivateTree`.
-    pub(crate) fn get_private_tree_mut(&mut self) -> &mut PrivateTree {
+    pub(crate) fn private_tree_mut(&mut self) -> &mut PrivateTree {
         &mut self.private_tree
     }
 
@@ -148,16 +148,30 @@ impl RatchetTree {
         NodeIndex::from(self.nodes.len())
     }
 
-    pub fn get_public_key_tree(&self) -> Vec<Option<Node>> {
+    /// Get a vector with all nodes in the tree, containing `None` for blank
+    /// nodes.
+    pub fn public_key_tree(&self) -> Vec<Option<&Node>> {
         let mut tree = vec![];
         for node in self.nodes.iter() {
             if node.is_blank() {
                 tree.push(None)
             } else {
-                tree.push(Some(node.clone()))
+                tree.push(Some(node))
             }
         }
         tree
+    }
+
+    /// Get a vector with a copy of all nodes in the tree, containing `None` for
+    /// blank nodes.
+    pub fn public_key_tree_copy(&self) -> Vec<Option<Node>> {
+        self.public_key_tree()
+            .iter()
+            .map(|&n| match n {
+                Some(v) => Some(v.clone()),
+                None => None,
+            })
+            .collect()
     }
 
     pub(crate) fn leaf_count(&self) -> LeafIndex {
@@ -604,7 +618,7 @@ impl RatchetTree {
                     self.nodes[d.as_usize()].node = Some(parent_node);
                 }
             }
-            added_members.push((leaf_index, new_kp.get_credential().clone()));
+            added_members.push((leaf_index, new_kp.credential().clone()));
         }
         // Add the remaining nodes.
         let mut new_nodes = Vec::with_capacity(num_new_kp * 2);
@@ -615,7 +629,7 @@ impl RatchetTree {
                 Node::new_leaf(Some((*add_proposal).clone())),
             ]);
             let node_index = NodeIndex::from(leaf_index);
-            added_members.push((node_index, add_proposal.get_credential().clone()));
+            added_members.push((node_index, add_proposal.credential().clone()));
             leaf_index += 2;
         }
         self.nodes.extend(new_nodes);

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -49,7 +49,7 @@ impl Node {
         match self.node_type {
             NodeType::Leaf => {
                 if let Some(ref kp) = self.key_package {
-                    Some(kp.get_hpke_init_key())
+                    Some(kp.hpke_init_key())
                 } else {
                     None
                 }

--- a/src/tree/node.rs
+++ b/src/tree/node.rs
@@ -100,11 +100,11 @@ impl Node {
                         key_package.get_extension(ExtensionType::ParentHash);
                     match parent_hash_extension {
                         Some(phe) => {
-                            let phe = match phe.to_parent_hash_extension_ref() {
+                            let phe = match phe.to_parent_hash_extension() {
                                 Ok(phe) => phe,
                                 Err(_) => return None,
                             };
-                            Some(phe.get_parent_hash_ref().to_vec())
+                            Some(phe.parent_hash().to_vec())
                         }
                         None => None,
                     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -68,7 +68,7 @@ pub fn _print_tree(tree: &RatchetTree, message: &str) {
                                 .as_any()
                                 .downcast_ref::<ParentHashExtension>()
                                 .expect("Library error");
-                            parent_hash_extension.get_parent_hash_ref().to_vec()
+                            parent_hash_extension.parent_hash().to_vec()
                         } else {
                             vec![]
                         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -58,7 +58,7 @@ pub fn _print_tree(tree: &RatchetTree, message: &str) {
                 NodeType::Leaf => {
                     print!("\tL");
                     let key_bytes = if let Some(kp) = &node.key_package {
-                        kp.get_hpke_init_key().as_slice()
+                        kp.hpke_init_key().as_slice()
                     } else {
                         &[]
                     };

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -32,7 +32,7 @@ impl<'a> Validator<'a> {
         match proposal {
             Proposal::Add(add_proposal) => {
                 let kp = add_proposal.key_package.clone();
-                let credential = kp.get_credential();
+                let credential = kp.credential();
                 let in_roster = members.iter().any(|m| m == credential);
                 if in_roster {
                     return false;
@@ -41,7 +41,7 @@ impl<'a> Validator<'a> {
             }
             Proposal::Update(update_proposal) => {
                 let kp = update_proposal.key_package.clone();
-                let credential = kp.get_credential();
+                let credential = kp.credential();
                 let in_roster = members.iter().any(|m| m == credential);
                 if !in_roster {
                     return false;

--- a/tests/test_group.rs
+++ b/tests/test_group.rs
@@ -100,7 +100,7 @@ fn create_commit_optional_path() {
         Ok(_) => {}
         Err(e) => panic!("Error applying commit: {:?}", e),
     };
-    let ratchet_tree = group_alice_1234.tree().get_public_key_tree();
+    let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
 
     // Bob creates group from Welcome
     let mut group_bob_1234 = match MlsGroup::new_from_welcome(
@@ -113,8 +113,8 @@ fn create_commit_optional_path() {
     };
 
     assert_eq!(
-        group_alice_1234.tree().get_public_key_tree(),
-        group_alice_1234.tree().get_public_key_tree()
+        group_alice_1234.tree().public_key_tree(),
+        group_alice_1234.tree().public_key_tree()
     );
 
     // Alice updates
@@ -279,7 +279,7 @@ fn group_operations() {
         group_alice_1234
             .apply_commit(mls_plaintext_commit, epoch_proposals, vec![])
             .expect("error applying commit");
-        let ratchet_tree = group_alice_1234.tree().get_public_key_tree();
+        let ratchet_tree = group_alice_1234.tree().public_key_tree_copy();
 
         let mut group_bob = match MlsGroup::new_from_welcome(
             welcome_bundle_alice_bob_option.unwrap(),
@@ -291,9 +291,7 @@ fn group_operations() {
         };
 
         // Make sure that both groups have the same public tree
-        if group_alice_1234.tree().get_public_key_tree()
-            != group_alice_1234.tree().get_public_key_tree()
-        {
+        if group_alice_1234.tree().public_key_tree() != group_alice_1234.tree().public_key_tree() {
             _print_tree(&group_alice_1234.tree(), "Alice added Bob");
             panic!("Different public trees");
         }

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -25,7 +25,7 @@ macro_rules! key_package_generation {
                 CredentialBundle::new(id, CredentialType::Basic, ciphersuite.name()).unwrap();
             let kpb = KeyPackageBundle::new(ciphersuite.name(), &credential_bundle, Vec::new());
 
-            let extensions = kpb.get_key_package().get_extensions_ref();
+            let extensions = kpb.get_key_package().extensions();
 
             // The capabilities extension must be present and valid.
             // It's added automatically.

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -34,7 +34,7 @@ macro_rules! key_package_generation {
                 .find(|e| e.get_type() == ExtensionType::Capabilities)
                 .expect("Capabilities extension is missing in key package");
             let _capabilities_extension = capabilities_extension
-                .to_capabilities_extension_ref()
+                .to_capabilities_extension()
                 .unwrap();
             // TODO: #101 test capabilities.
 

--- a/tests/test_key_packages.rs
+++ b/tests/test_key_packages.rs
@@ -33,9 +33,8 @@ macro_rules! key_package_generation {
                 .iter()
                 .find(|e| e.get_type() == ExtensionType::Capabilities)
                 .expect("Capabilities extension is missing in key package");
-            let _capabilities_extension = capabilities_extension
-                .to_capabilities_extension()
-                .unwrap();
+            let _capabilities_extension =
+                capabilities_extension.to_capabilities_extension().unwrap();
             // TODO: #101 test capabilities.
 
             // Lifetime extension must be present and valid.


### PR DESCRIPTION
* Remove a couple `get_` in names.
* Don't copy the tree every time with `public_key_tree`.